### PR TITLE
option to hide join/part/quit messages

### DIFF
--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -100,14 +100,14 @@ class _JoinLeaveWidget(ttk.Frame):
             value=True,
             text="Show join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._hide_these_users_entry.pack(fill="x", padx=[20, 50])
+        self._hide_these_users_entry.pack(fill="x", padx=(20, 50))
         ttk.Radiobutton(
             self,
             variable=self._show_by_default_var,
             value=False,
             text="Hide join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._show_these_users_entry.pack(fill="x", padx=[20, 50])
+        self._show_these_users_entry.pack(fill="x", padx=(20, 50))
 
         self._show_by_default_var.trace_add("write", self._update_entry_disableds)
 

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -390,7 +390,7 @@ def show_connection_settings_dialog(
         dialog.minsize(450, 200)
     else:
         content = _DialogContent(dialog, initial_config, connecting_to_new_server=False)
-        dialog.title("Connection settings")
+        dialog.title("Server settings")
         dialog.minsize(450, 300)
 
     content.pack(fill="both", expand=True)

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -57,10 +57,10 @@ def load_from_file(config_dir: Path) -> Config | None:
                 server.setdefault("ssl", True)
                 server.setdefault("password", None)
                 server.setdefault("extra_notifications", [])
-                server.setdefault("join_leave_hiding", {
-                    "show_by_default": True,
-                    "exception_nicks": [],
-                })
+                server.setdefault(
+                    "join_leave_hiding",
+                    {"show_by_default": True, "exception_nicks": []},
+                )
             if "font_family" not in result or "font_size" not in result:
                 result["font_family"], result["font_size"] = get_default_fixed_font()
             return result
@@ -100,14 +100,14 @@ class _JoinLeaveWidget(ttk.Frame):
             value=True,
             text="Show join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._hide_these_users_entry.pack(fill="x", padx=[20,50])
+        self._hide_these_users_entry.pack(fill="x", padx=[20, 50])
         ttk.Radiobutton(
             self,
             variable=self._show_by_default_var,
             value=False,
             text="Hide join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._show_these_users_entry.pack(fill="x", padx=[20,50])
+        self._show_these_users_entry.pack(fill="x", padx=[20, 50])
 
         self._show_by_default_var.trace_add("write", self._update_entry_disableds)
 
@@ -122,20 +122,19 @@ class _JoinLeaveWidget(ttk.Frame):
     def set_from_config(self, config: JoinLeaveHidingConfig) -> None:
         self._show_by_default_var.set(config["show_by_default"])
         if config["show_by_default"]:
-            self._hide_these_users_entry.var.set(
-                " ".join(config["exception_nicks"])
-            )
+            self._hide_these_users_entry.var.set(" ".join(config["exception_nicks"]))
         else:
-            self._show_these_users_entry.var.set(
-                " ".join(config["exception_nicks"])
-            )
+            self._show_these_users_entry.var.set(" ".join(config["exception_nicks"]))
 
     def get_config(self) -> JoinLeaveHidingConfig:
         if self._show_by_default_var.get():
             exceptions = self._hide_these_users_entry.get().split()
         else:
             exceptions = self._show_these_users_entry.get().split()
-        return {"show_by_default": self._show_by_default_var.get(), "exception_nicks": exceptions}
+        return {
+            "show_by_default": self._show_by_default_var.get(),
+            "exception_nicks": exceptions,
+        }
 
 
 class _DialogContent(ttk.Frame):
@@ -356,7 +355,7 @@ class _DialogContent(ttk.Frame):
                 self._initial_config["join_leave_hiding"]
                 if self._join_part_quit is None
                 else self._join_part_quit.get_config()
-            )
+            ),
         }
         self.winfo_toplevel().destroy()
 

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -100,14 +100,14 @@ class _JoinLeaveWidget(ttk.Frame):
             value=True,
             text="Show join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._hide_these_users_entry.pack(fill="x")
+        self._hide_these_users_entry.pack(fill="x", padx=[20,50])
         ttk.Radiobutton(
             self,
             variable=self._show_by_default_var,
             value=False,
             text="Hide join/part/quit messages for all nicks except:",
         ).pack(fill="x")
-        self._show_these_users_entry.pack(fill="x")
+        self._show_these_users_entry.pack(fill="x", padx=[20,50])
 
         self._show_by_default_var.trace_add("write", self._update_entry_disableds)
 

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -87,7 +87,7 @@ class _EntryWithVar(ttk.Entry):
         self.var = var
 
 
-class _JoinPartQuitSettings(ttk.Frame):
+class _JoinLeaveWidget(ttk.Frame):
     def __init__(self, master: tkinter.Misc):
         super().__init__(master)
         self._show_by_default_var = tkinter.BooleanVar()
@@ -198,7 +198,7 @@ class _DialogContent(ttk.Frame):
         if connecting_to_new_server:
             self._join_part_quit = None
         else:
-            self._join_part_quit = _JoinPartQuitSettings(self)
+            self._join_part_quit = _JoinLeaveWidget(self)
             self._join_part_quit.grid(
                 row=self._rownumber, column=0, columnspan=3, sticky="we"
             )

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -18,7 +18,7 @@ else:
         TypedDict = object
 
 
-class ShowJoinPartQuitConfig(TypedDict):
+class JoinLeaveHidingConfig(TypedDict):
     show_by_default: bool
     exception_nicks: list[str]
 
@@ -33,7 +33,7 @@ class ServerConfig(TypedDict):
     password: str | None
     joined_channels: list[str]
     extra_notifications: list[str]  # channels to notify for all messages
-    show_join_part_quit: ShowJoinPartQuitConfig
+    join_leave_hiding: JoinLeaveHidingConfig
 
 
 class Config(TypedDict):
@@ -57,7 +57,7 @@ def load_from_file(config_dir: Path) -> Config | None:
                 server.setdefault("ssl", True)
                 server.setdefault("password", None)
                 server.setdefault("extra_notifications", [])
-                server.setdefault("show_join_part_quit", {
+                server.setdefault("join_leave_hiding", {
                     "show_by_default": True,
                     "exception_nicks": [],
                 })
@@ -119,7 +119,7 @@ class _JoinPartQuitSettings(ttk.Frame):
             self._show_these_users_entry.config(state="normal")
             self._hide_these_users_entry.config(state="disabled")
 
-    def set_from_config(self, config: ShowJoinPartQuitConfig) -> None:
+    def set_from_config(self, config: JoinLeaveHidingConfig) -> None:
         self._show_by_default_var.set(config["show_by_default"])
         if config["show_by_default"]:
             self._hide_these_users_entry.var.set(
@@ -130,7 +130,7 @@ class _JoinPartQuitSettings(ttk.Frame):
                 " ".join(config["exception_nicks"])
             )
 
-    def get_config(self) -> ShowJoinPartQuitConfig:
+    def get_config(self) -> JoinLeaveHidingConfig:
         if self._show_by_default_var.get():
             exceptions = self._hide_these_users_entry.get().split()
         else:
@@ -256,7 +256,7 @@ class _DialogContent(ttk.Frame):
         if self._channel_entry is not None:
             self._channel_entry.var.set(" ".join(initial_config["joined_channels"]))
         if self._join_part_quit is not None:
-            self._join_part_quit.set_from_config(initial_config["show_join_part_quit"])
+            self._join_part_quit.set_from_config(initial_config["join_leave_hiding"])
 
     def _create_entry(self, **kwargs: Any) -> _EntryWithVar:
         entry = _EntryWithVar(self, **kwargs)
@@ -352,8 +352,8 @@ class _DialogContent(ttk.Frame):
                 else self._channel_entry.get().split()
             ),
             "extra_notifications": self._initial_config["extra_notifications"],
-            "show_join_part_quit": (
-                self._initial_config["show_join_part_quit"]
+            "join_leave_hiding": (
+                self._initial_config["join_leave_hiding"]
                 if self._join_part_quit is None
                 else self._join_part_quit.get_config()
             )
@@ -382,7 +382,7 @@ def show_connection_settings_dialog(
                 "password": None,
                 "joined_channels": ["##learnpython"],
                 "extra_notifications": [],
-                "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
+                "join_leave_hiding": {"show_by_default": True, "exception_nicks": []},
             },
             connecting_to_new_server=True,
         )

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -403,7 +403,7 @@ class IrcWidget(ttk.PanedWindow):
 
         elif isinstance(view, ServerView):
             self._contextmenu.add_command(
-                label="Connection settings...", command=view.show_config_dialog
+                label="Server settings...", command=view.show_config_dialog
             )
 
     def _view_selector_right_click(

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -132,7 +132,11 @@ class View:
         return parent_view
 
     def add_message(
-        self, sender: str, *chunks: tuple[str, list[str]], pinged: bool = False, show_in_gui: bool = True
+        self,
+        sender: str,
+        *chunks: tuple[str, list[str]],
+        pinged: bool = False,
+        show_in_gui: bool = True,
     ) -> None:
         if show_in_gui:
             # scroll down all the way if the user hasn't scrolled up manually
@@ -203,8 +207,11 @@ class View:
             extra = ""
         else:
             extra = " (" + reason + ")"
-        self.add_message("*", (nick, ["other-nick"]), (" quit." + extra, []),
-            show_in_gui=self.server_view.should_show_join_leave_message(nick)
+        self.add_message(
+            "*",
+            (nick, ["other-nick"]),
+            (" quit." + extra, []),
+            show_in_gui=self.server_view.should_show_join_leave_message(nick),
         )
 
 
@@ -318,7 +325,9 @@ class ServerView(View):
             elif isinstance(event, backend.SentPrivmsg):
                 channel_view = self.find_channel(event.recipient)
                 if channel_view is None:
-                    assert not re.fullmatch(backend.CHANNEL_REGEX, event.recipient), event.recipient
+                    assert not re.fullmatch(
+                        backend.CHANNEL_REGEX, event.recipient
+                    ), event.recipient
                     pm_view = self.find_pm(event.recipient)
                     if pm_view is None:
                         # start of a new PM conversation
@@ -453,8 +462,10 @@ class ChannelView(View):
     def on_join(self, nick: str) -> None:
         self.userlist.add_user(nick)
         self.add_message(
-            "*", (nick, ["other-nick"]), (f" joined {self.channel_name}.", []),
-            show_in_gui=self.server_view.should_show_join_leave_message(nick)
+            "*",
+            (nick, ["other-nick"]),
+            (f" joined {self.channel_name}.", []),
+            show_in_gui=self.server_view.should_show_join_leave_message(nick),
         )
 
     def on_part(self, nick: str, reason: str | None) -> None:
@@ -464,8 +475,10 @@ class ChannelView(View):
         else:
             extra = " (" + reason + ")"
         self.add_message(
-            "*", (nick, ["other-nick"]), (f" left {self.channel_name}." + extra, []),
-            show_in_gui=self.server_view.should_show_join_leave_message(nick)
+            "*",
+            (nick, ["other-nick"]),
+            (f" left {self.channel_name}." + extra, []),
+            show_in_gui=self.server_view.should_show_join_leave_message(nick),
         )
 
     def on_self_changed_nick(self, old: str, new: str) -> None:

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -132,36 +132,40 @@ class View:
         return parent_view
 
     def add_message(
-        self, sender: str, *chunks: tuple[str, list[str]], pinged: bool = False
+        self, sender: str, *chunks: tuple[str, list[str]], pinged: bool = False, show_in_gui: bool = True
     ) -> None:
-        # scroll down all the way if the user hasn't scrolled up manually
-        do_the_scroll = self.textwidget.yview()[1] == 1.0
+        if show_in_gui:
+            # scroll down all the way if the user hasn't scrolled up manually
+            do_the_scroll = self.textwidget.yview()[1] == 1.0
 
-        # nicks are limited to 16 characters at least on freenode
-        # len(sender) > 16 is not a problem:
-        #    >>> ' ' * (-3)
-        #    ''
-        padding = " " * (16 - len(sender))
+            # nicks are limited to 16 characters at least on freenode
+            # len(sender) > 16 is not a problem:
+            #    >>> ' ' * (-3)
+            #    ''
+            padding = " " * (16 - len(sender))
 
-        if sender == "*":
-            sender_tags = []
-        elif sender == self.server_view.core.nick:
-            sender_tags = ["self-nick"]
-        else:
-            sender_tags = ["other-nick"]
+            if sender == "*":
+                sender_tags = []
+            elif sender == self.server_view.core.nick:
+                sender_tags = ["self-nick"]
+            else:
+                sender_tags = ["other-nick"]
 
-        self.textwidget.config(state="normal")
-        start = self.textwidget.index("end - 1 char")
-        self.textwidget.insert("end", time.strftime("[%H:%M]") + " " + padding)
-        self.textwidget.insert("end", sender, sender_tags)
-        self.textwidget.insert("end", " | ")
-        flatten = itertools.chain.from_iterable
-        if chunks:
-            self.textwidget.insert("end", *flatten(chunks))  # type: ignore
-        self.textwidget.insert("end", "\n")
-        if pinged:
-            self.textwidget.tag_add("pinged", start, "end - 1 char")
-        self.textwidget.config(state="disabled")
+            self.textwidget.config(state="normal")
+            start = self.textwidget.index("end - 1 char")
+            self.textwidget.insert("end", time.strftime("[%H:%M]") + " " + padding)
+            self.textwidget.insert("end", sender, sender_tags)
+            self.textwidget.insert("end", " | ")
+            flatten = itertools.chain.from_iterable
+            if chunks:
+                self.textwidget.insert("end", *flatten(chunks))  # type: ignore
+            self.textwidget.insert("end", "\n")
+            if pinged:
+                self.textwidget.tag_add("pinged", start, "end - 1 char")
+            self.textwidget.config(state="disabled")
+
+            if do_the_scroll:
+                self.textwidget.see("end")
 
         if self.log_file is not None:
             print(
@@ -172,9 +176,6 @@ class View:
                 file=self.log_file,
                 flush=True,
             )
-
-        if do_the_scroll:
-            self.textwidget.see("end")
 
     def on_connectivity_message(self, message: str, *, error: bool = False) -> None:
         self.add_message("", (message, ["error" if error else "info"]))
@@ -202,17 +203,22 @@ class View:
             extra = ""
         else:
             extra = " (" + reason + ")"
-        self.add_message("*", (nick, ["other-nick"]), (" quit." + extra, []))
+        self.add_message("*", (nick, ["other-nick"]), (" quit." + extra, []),
+            show_in_gui=self.server_view.should_show_join_part_quit(nick)
+        )
 
 
 class ServerView(View):
-    core: backend.IrcCore  # no idea why mypy need this
+    # no idea why mypy need these
+    core: backend.IrcCore
+    hide_join_part_quit: set[str]
 
     def __init__(self, irc_widget: IrcWidget, server_config: config.ServerConfig):
         super().__init__(irc_widget)
         irc_widget.view_selector.item(self.view_id, text=server_config["host"])
         self.core = backend.IrcCore(server_config)
         self.extra_notifications = set(server_config["extra_notifications"])
+        self._join_part_quit_config = server_config["show_join_part_quit"]
 
         self.core.start()
         self.handle_events()
@@ -220,6 +226,12 @@ class ServerView(View):
     @property
     def server_view(self) -> ServerView:
         return self
+
+    def should_show_join_part_quit(self, nick: str) -> bool:
+        is_exceptional = nick.lower() in (
+            n.lower() for n in self._join_part_quit_config["exception_nicks"]
+        )
+        return self._join_part_quit_config["show_by_default"] ^ is_exceptional
 
     def get_subviews(self, *, include_server: bool = False) -> list[View]:
         result: list[View] = []
@@ -308,7 +320,7 @@ class ServerView(View):
             elif isinstance(event, backend.SentPrivmsg):
                 channel_view = self.find_channel(event.recipient)
                 if channel_view is None:
-                    assert not re.fullmatch(backend.CHANNEL_REGEX, event.recipient)
+                    assert not re.fullmatch(backend.CHANNEL_REGEX, event.recipient), event.recipient
                     pm_view = self.find_pm(event.recipient)
                     if pm_view is None:
                         # start of a new PM conversation
@@ -391,6 +403,7 @@ class ServerView(View):
                 key=(lambda chan: channels.index(chan) if chan in channels else -1),
             ),
             "extra_notifications": list(self.extra_notifications),
+            "show_join_part_quit": self._join_part_quit_config,
         }
 
     def show_config_dialog(self) -> None:
@@ -399,6 +412,7 @@ class ServerView(View):
             initial_config=self.get_current_config(),
         )
         if new_config is not None:
+            self._join_part_quit_config = new_config["show_join_part_quit"]
             self.core.apply_config_and_reconnect(new_config)
             # TODO: autojoin setting would be better in right-click
             for subview in self.get_subviews():
@@ -441,7 +455,8 @@ class ChannelView(View):
     def on_join(self, nick: str) -> None:
         self.userlist.add_user(nick)
         self.add_message(
-            "*", (nick, ["other-nick"]), (f" joined {self.channel_name}.", [])
+            "*", (nick, ["other-nick"]), (f" joined {self.channel_name}.", []),
+            show_in_gui=self.server_view.should_show_join_part_quit(nick)
         )
 
     def on_part(self, nick: str, reason: str | None) -> None:
@@ -451,7 +466,8 @@ class ChannelView(View):
         else:
             extra = " (" + reason + ")"
         self.add_message(
-            "*", (nick, ["other-nick"]), (f" left {self.channel_name}." + extra, [])
+            "*", (nick, ["other-nick"]), (f" left {self.channel_name}." + extra, []),
+            show_in_gui=self.server_view.should_show_join_part_quit(nick)
         )
 
     def on_self_changed_nick(self, old: str, new: str) -> None:

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -218,7 +218,7 @@ class ServerView(View):
         irc_widget.view_selector.item(self.view_id, text=server_config["host"])
         self.core = backend.IrcCore(server_config)
         self.extra_notifications = set(server_config["extra_notifications"])
-        self._join_part_quit_config = server_config["show_join_part_quit"]
+        self._join_part_quit_config = server_config["join_leave_hiding"]
 
         self.core.start()
         self.handle_events()
@@ -403,7 +403,7 @@ class ServerView(View):
                 key=(lambda chan: channels.index(chan) if chan in channels else -1),
             ),
             "extra_notifications": list(self.extra_notifications),
-            "show_join_part_quit": self._join_part_quit_config,
+            "join_leave_hiding": self._join_part_quit_config,
         }
 
     def show_config_dialog(self) -> None:
@@ -412,7 +412,7 @@ class ServerView(View):
             initial_config=self.get_current_config(),
         )
         if new_config is not None:
-            self._join_part_quit_config = new_config["show_join_part_quit"]
+            self._join_part_quit_config = new_config["join_leave_hiding"]
             self.core.apply_config_and_reconnect(new_config)
             # TODO: autojoin setting would be better in right-click
             for subview in self.get_subviews():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def alice_and_bob(hircd, root_window, wait_until, mocker):
                         "realname": f"{name}'s real name",
                         "joined_channels": ["#autojoin"],
                         "extra_notifications": ["#bobnotify"] if name == "Bob" else [],
-                        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
+                        "join_leave_hiding": {"show_by_default": True, "exception_nicks": []},
                     }
                 ],
                 "font_family": "this font does not exist",  # falls back to default font

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def alice_and_bob(hircd, root_window, wait_until, mocker):
                         "realname": f"{name}'s real name",
                         "joined_channels": ["#autojoin"],
                         "extra_notifications": ["#bobnotify"] if name == "Bob" else [],
+                        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
                     }
                 ],
                 "font_family": "this font does not exist",  # falls back to default font

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,10 @@ def alice_and_bob(hircd, root_window, wait_until, mocker):
                         "realname": f"{name}'s real name",
                         "joined_channels": ["#autojoin"],
                         "extra_notifications": ["#bobnotify"] if name == "Bob" else [],
-                        "join_leave_hiding": {"show_by_default": True, "exception_nicks": []},
+                        "join_leave_hiding": {
+                            "show_by_default": True,
+                            "exception_nicks": [],
+                        },
                     }
                 ],
                 "font_family": "this font does not exist",  # falls back to default font

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -119,4 +119,3 @@ def test_incorrect_usage(alice, wait_until, command, error):
     alice.on_enter_pressed()
     wait_until(lambda: alice.text().endswith(error + "\n"))
     assert alice.entry.get() == command  # give user chance to correct easily
-

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -119,3 +119,4 @@ def test_incorrect_usage(alice, wait_until, command, error):
     alice.on_enter_pressed()
     wait_until(lambda: alice.text().endswith(error + "\n"))
     assert alice.entry.get() == command  # give user chance to correct easily
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import copy
 from tkinter import ttk
 from tkinter.font import Font
 
@@ -28,17 +29,18 @@ def test_old_config_format(tmp_path, root_window):
             {
                 "host": "irc.libera.chat",
                 "port": 6697,
-                "ssl": True,  # added
+                "ssl": True,
                 "nick": "Akuli2",
                 "username": "Akuli2",
                 "realname": "Akuli2",
-                "password": None,  # added
+                "password": None,
                 "joined_channels": ["##learnpython"],
-                "extra_notifications": [],  # added
+                "extra_notifications": [],
+                "hide_join_part_quit": [],
             }
         ],
-        "font_family": Font(name="TkFixedFont", exists=True)["family"],  # added
-        "font_size": Font(name="TkFixedFont", exists=True)["size"],  # added
+        "font_family": Font(name="TkFixedFont", exists=True)["family"],
+        "font_size": Font(name="TkFixedFont", exists=True)["size"],
     }
 
 
@@ -103,6 +105,7 @@ def test_nothing_changes_if_you_only_click_reconnect(root_window, monkeypatch):
         "realname": "xd lol",
         "joined_channels": ["#lol", "#wut"],
         "extra_notifications": ["#wut"],
+        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
     }
     assert (
         show_connection_settings_dialog(
@@ -119,10 +122,56 @@ def test_default_settings(root_window, monkeypatch):
     )
     assert config.pop("nick") == config.pop("username") == config.pop("realname")
     assert config == {
-        "extra_notifications": [],
         "host": "irc.libera.chat",
         "joined_channels": ["##learnpython"],
         "password": None,
         "port": 6697,
         "ssl": True,
+        "extra_notifications": [],
+        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
     }
+
+
+def test_join_part_quit_messages(alice, bob, wait_until, monkeypatch):
+    bob.entry.insert("end", "/join #lol")
+    bob.on_enter_pressed()
+    wait_until(lambda: "The topic of #lol is:" in bob.text())
+
+    alice.entry.insert("end", "/join #lol")
+    alice.on_enter_pressed()
+    wait_until(lambda: "The topic of #lol is:" in alice.text())
+    alice.entry.insert("end", "/part #lol")
+    alice.on_enter_pressed()
+
+    wait_until(lambda: "Alice joined #lol." in bob.text())
+    wait_until(lambda: "Alice left #lol." in bob.text())
+
+
+def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
+    bob.entry.insert("end", "/join #lol")
+    bob.on_enter_pressed()
+    wait_until(lambda: "The topic of #lol is:" in bob.text())
+
+    # Configure Bob to ignore Alice joining/quitting
+    def bob_config(transient_to, initial_config):
+        new_config = copy.deepcopy(initial_config)
+        new_config["show_join_part_quit"]["exception_nicks"].append("aLiCe")
+        return new_config
+
+    monkeypatch.setattr("mantaray.config.show_connection_settings_dialog", bob_config)
+    bob.get_server_views()[0].show_config_dialog()
+
+    alice.entry.insert("end", "/join #lol")
+    alice.on_enter_pressed()
+    wait_until(lambda: "The topic of #lol is:" in alice.text())
+    alice.entry.insert("end", "Hello Bob")
+    alice.on_enter_pressed()
+    alice.entry.insert("end", "/part #lol")
+    alice.on_enter_pressed()
+
+    wait_until(
+        lambda: "Hello Bob" in bob.text()
+        and "Alice" not in bob.get_current_view().userlist.get_nicks()
+    )
+    assert "Alice joined #lol." not in bob.text()
+    assert "Alice left #lol." not in bob.text()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,7 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     alice.entry.insert("end", "Hello Bob")
     alice.on_enter_pressed()
     alice.entry.insert("end", "/quit")
+    alice.on_enter_pressed()
     wait_until(lambda: not alice.winfo_exists())
 
     wait_until(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,7 +105,7 @@ def test_nothing_changes_if_you_only_click_reconnect(root_window, monkeypatch):
         "realname": "xd lol",
         "joined_channels": ["#lol", "#wut"],
         "extra_notifications": ["#wut"],
-        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
+        "join_leave_hiding": {"show_by_default": True, "exception_nicks": []},
     }
     assert (
         show_connection_settings_dialog(
@@ -128,7 +128,7 @@ def test_default_settings(root_window, monkeypatch):
         "port": 6697,
         "ssl": True,
         "extra_notifications": [],
-        "show_join_part_quit": {"show_by_default": True, "exception_nicks": []},
+        "join_leave_hiding": {"show_by_default": True, "exception_nicks": []},
     }
 
 
@@ -155,7 +155,7 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     # Configure Bob to ignore Alice joining/quitting
     def bob_config(transient_to, initial_config):
         new_config = copy.deepcopy(initial_config)
-        new_config["show_join_part_quit"]["exception_nicks"].append("aLiCe")
+        new_config["join_leave_hiding"]["exception_nicks"].append("aLiCe")
         return new_config
 
     monkeypatch.setattr("mantaray.config.show_connection_settings_dialog", bob_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,10 +164,16 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     alice.entry.insert("end", "/join #lol")
     alice.on_enter_pressed()
     wait_until(lambda: "The topic of #lol is:" in alice.text())
-    alice.entry.insert("end", "Hello Bob")
-    alice.on_enter_pressed()
     alice.entry.insert("end", "/part #lol")
     alice.on_enter_pressed()
+    wait_until(lambda: not alice.get_server_views()[0].find_channel("#lol"))
+    alice.entry.insert("end", "/join #lol")
+    alice.on_enter_pressed()
+    wait_until(lambda: "The topic of #lol is:" in alice.text())
+    alice.entry.insert("end", "Hello Bob")
+    alice.on_enter_pressed()
+    alice.entry.insert("end", "/quit")
+    wait_until(lambda: not alice.winfo_exists())
 
     wait_until(
         lambda: "Hello Bob" in bob.text()


### PR DESCRIPTION
Fixes #110 

- [x] Rename `show_join_part_quit` to something better, e.g. `join_leave_hiding`
- [x] Rename "Connection settings" to "Server settings"