### PR TITLE
Logging improvements

### DIFF
--- a/alice/config.json
+++ b/alice/config.json
@@ -5,7 +5,7 @@
       "port": 6667,
       "ssl": false,
       "nick": "Alice",
-      "username": "Alice",
+      "username": "AliceUsr",
       "realname": "Alice's real name",
       "joined_channels": ["#autojoin"]
     }

--- a/bob/config.json
+++ b/bob/config.json
@@ -5,7 +5,7 @@
       "port": 6667,
       "ssl": false,
       "nick": "Bob",
-      "username": "Bob",
+      "username": "BobUsr",
       "realname": "Bob's real name",
       "joined_channels": ["#autojoin"],
       "extra_notifications": ["#bobnotify"]

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -9,7 +9,7 @@ from tkinter.font import Font
 from typing import Any
 from pathlib import Path
 
-from mantaray import config, commands, colors
+from mantaray import config, commands, colors, logs
 from mantaray.views import View, ServerView, ChannelView, PMView
 
 
@@ -79,7 +79,7 @@ def ask_new_nick(parent: tkinter.Tk | tkinter.Toplevel, old_nick: str) -> str:
 class IrcWidget(ttk.PanedWindow):
     def __init__(self, master: tkinter.Misc, file_config: config.Config, log_dir: Path):
         super().__init__(master, orient="horizontal")
-        self.log_dir = log_dir
+        self.log_manager = logs.LogManager(log_dir)
 
         self.font = Font(
             family=file_config["font_family"], size=file_config["font_size"]

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -358,12 +358,12 @@ class IrcWidget(ttk.PanedWindow):
             assert isinstance(subview, (ChannelView, PMView))
             self.remove_view(subview)
 
+        server_view.close_log_file()
         if len(self.view_selector.get_children("")) == 1:
             self.destroy()
         else:
             self._select_another_view(server_view)
             self.view_selector.delete(server_view.view_id)
-            server_view.close_log_file()
             server_view.destroy_widgets()
             del self.views_by_id[server_view.view_id]
 

--- a/mantaray/logs.py
+++ b/mantaray/logs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 class LogManager:
 
     def __init__(self, log_dir: Path):
-        self._log_dir = log_dir
+        self.log_dir = log_dir
         self._opened: dict[IO[str], Path] = {}
 
     def open_log_file(self, server_name: str, channel_or_nick: str) -> IO[str]:
@@ -18,10 +18,10 @@ class LogManager:
         # Even if someone's nickname is "server", logs shouldn't get mixed.
         # The actual server.log is created first.
         n = 1
-        path = self._log_dir / safe_folder / f"{safe_file}.log"
+        path = self.log_dir / safe_folder / f"{safe_file}.log"
         while path in self._opened.values():
             n += 1
-            path = self._log_dir / safe_folder / f"{safe_file}({n}).log"
+            path = self.log_dir / safe_folder / f"{safe_file}({n}).log"
 
         path.parent.mkdir(parents=True, exist_ok=True)
         file = path.open("a", encoding="utf-8")

--- a/mantaray/logs.py
+++ b/mantaray/logs.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 
 class LogManager:
-
     def __init__(self, log_dir: Path):
         self.log_dir = log_dir
         self._opened: dict[IO[str], Path] = {}

--- a/mantaray/logs.py
+++ b/mantaray/logs.py
@@ -1,0 +1,38 @@
+import re
+import sys
+import time
+from typing import IO
+from pathlib import Path
+
+
+class LogManager:
+
+    def __init__(self, log_dir: Path):
+        self._log_dir = log_dir
+        self._opened: dict[IO[str], Path] = {}
+
+    def open_log_file(self, server_name: str, channel_or_nick: str) -> IO[str]:
+        safe_folder = re.sub("[^A-Za-z0-9-_#]", "_", server_name.lower())
+        safe_file = re.sub("[^A-Za-z0-9-_#]", "_", channel_or_nick.lower())
+
+        # Even if someone's nickname is "server", logs shouldn't get mixed.
+        # The actual server.log is created first.
+        n = 1
+        path = self._log_dir / safe_folder / f"{safe_file}.log"
+        while path in self._opened.values():
+            n += 1
+            path = self._log_dir / safe_folder / f"{safe_file}({n}).log"
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file = path.open("a", encoding="utf-8")
+        if sys.platform != "win32":
+            path.chmod(0o600)
+
+        print("\n\n*** LOGGING BEGINS", time.asctime(), file=file, flush=True)
+        self._opened[file] = path
+        return file
+
+    def close_log_file(self, file: IO[str]) -> None:
+        print("*** LOGGING ENDS", time.asctime(), file=file, flush=True)
+        file.close()
+        del self._opened[file]

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -125,7 +125,9 @@ class View:
 
     def reopen_log_file(self) -> None:
         self.close_log_file()
-        self.log_file = self.irc_widget.log_manager.open_log_file(self.server_view.view_name, self.get_log_name())
+        self.log_file = self.irc_widget.log_manager.open_log_file(
+            self.server_view.view_name, self.get_log_name()
+        )
 
     def _update_view_selector(self) -> None:
         if self.notification_count == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def alice_and_bob(irc_server, root_window, wait_until, mocker):
                 server_view.core.wait_for_threads_to_stop()
         # On windows, we need to wait until log files are closed before removing them
         wait_until(lambda: not irc_widget.winfo_exists())
-        shutil.rmtree(irc_widget.log_dir)
+        shutil.rmtree(irc_widget.log_manager.log_dir)
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,7 +65,7 @@ def test_changing_host(alice, mocker, wait_until):
 
     assert alice.view_selector.item(server_view.view_id, "text") == "127.0.0.1"
     assert (alice.log_manager.log_dir / "localhost" / "#autojoin.log").exists()
-    assert (alice.log_manager.log_dir / "127.0.0.1" / "#autojoin.log").exists()
+    assert (alice.log_manager.log_dir / "127_0_0_1" / "#autojoin.log").exists()
 
 
 def click(window, button_text):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,7 +64,9 @@ def test_changing_host(alice, mocker, wait_until):
     wait_until(lambda: alice.text().count("The topic of #autojoin is:") == 2)
 
     assert alice.view_selector.item(server_view.view_id, "text") == "127.0.0.1"
+    assert (alice.log_manager.log_dir / "localhost" / "server.log").exists()
     assert (alice.log_manager.log_dir / "localhost" / "#autojoin.log").exists()
+    assert (alice.log_manager.log_dir / "127_0_0_1" / "server.log").exists()
     assert (alice.log_manager.log_dir / "127_0_0_1" / "#autojoin.log").exists()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,8 +64,8 @@ def test_changing_host(alice, mocker, wait_until):
     wait_until(lambda: alice.text().count("The topic of #autojoin is:") == 2)
 
     assert alice.view_selector.item(server_view.view_id, "text") == "127.0.0.1"
-    assert (alice.log_dir / "localhost" / "#autojoin.log").exists()
-    assert (alice.log_dir / "127.0.0.1" / "#autojoin.log").exists()
+    assert (alice.log_manager.log_dir / "localhost" / "#autojoin.log").exists()
+    assert (alice.log_manager.log_dir / "127.0.0.1" / "#autojoin.log").exists()
 
 
 def click(window, button_text):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,5 @@
 import re
+from mantaray.views import ServerView
 
 
 def _remove_timestamps(string):
@@ -103,6 +104,46 @@ def test_funny_filenames(alice, bob, wait_until):
 
 *** LOGGING BEGINS <time>
 <time>  {Bruh}  blah
+""",
+    )
+
+
+def test_same_log_file_name(alice, bob, wait_until):
+    # Prevent Bob from noticing nick change, to make Alice appear as two different users.
+    # Ideally there would be a way for tests to have 3 different people talking with each other
+    alice.entry.insert("end", "/part #autojoin")
+    alice.on_enter_pressed()
+    wait_until(lambda: isinstance(alice.get_current_view(), ServerView))
+
+    alice.entry.insert("end", "/nick {foo")
+    alice.on_enter_pressed()
+    wait_until(lambda: "You are now known as {foo." in alice.text())
+    alice.entry.insert("end", "/msg Bob hello 1")
+    alice.on_enter_pressed()
+    wait_until(lambda: "hello 1" in bob.text())
+
+    alice.entry.insert("end", "/nick }foo")
+    alice.on_enter_pressed()
+    wait_until(lambda: "You are now known as }foo." in alice.text())
+    alice.entry.insert("end", "/msg Bob hello 2")
+    alice.on_enter_pressed()
+    wait_until(lambda: "hello 2" in bob.text())
+
+    check_log(
+        bob.log_manager.log_dir / "localhost" / "_foo.log",
+        """
+
+*** LOGGING BEGINS <time>
+<time>  {foo    hello 1
+""",
+    )
+
+    check_log(
+        bob.log_manager.log_dir / "localhost" / "_foo(2).log",
+        """
+
+*** LOGGING BEGINS <time>
+<time>  }foo    hello 2
 """,
     )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -27,7 +27,7 @@ def test_basic(alice, bob, wait_until):
     wait_until(lambda: not alice.winfo_exists())
 
     check_log(
-        alice.log_dir / "localhost" / "#autojoin.log",
+        alice.log_manager.log_dir / "localhost" / "#autojoin.log",
         """
 
 *** LOGGING BEGINS <time>
@@ -58,7 +58,7 @@ def test_pm_logs(alice, bob, wait_until):
     wait_until(lambda: not alice.winfo_exists())
 
     check_log(
-        alice.log_dir / "localhost" / "#autojoin.log",
+        alice.log_manager.log_dir / "localhost" / "#autojoin.log",
         """
 
 *** LOGGING BEGINS <time>
@@ -69,7 +69,7 @@ def test_pm_logs(alice, bob, wait_until):
 """,
     )
     check_log(
-        alice.log_dir / "localhost" / "bob.log",
+        alice.log_manager.log_dir / "localhost" / "bob.log",
         """
 
 *** LOGGING BEGINS <time>
@@ -79,7 +79,7 @@ def test_pm_logs(alice, bob, wait_until):
 """,
     )
     check_log(
-        alice.log_dir / "localhost" / "blabla.log",
+        alice.log_manager.log_dir / "localhost" / "blabla.log",
         """
 
 *** LOGGING BEGINS <time>
@@ -98,10 +98,34 @@ def test_funny_filenames(alice, bob, wait_until):
     wait_until(lambda: "blah" in bob.text())
 
     check_log(
-        bob.log_dir / "localhost" / "_bruh_.log",
+        bob.log_manager.log_dir / "localhost" / "_bruh_.log",
         """
 
 *** LOGGING BEGINS <time>
 <time>  {Bruh}  blah
+""",
+    )
+
+
+def test_someone_has_nickname_server(alice, bob, wait_until):
+    alice.entry.insert("end", "/nick server")
+    alice.on_enter_pressed()
+    wait_until(lambda: "You are now known as server." in alice.text())
+
+    alice.entry.insert("end", "/msg Bob blah")
+    alice.on_enter_pressed()
+    wait_until(lambda: "blah" in bob.text())
+
+    bob.entry.insert("end", "hello there")
+    bob.on_enter_pressed()
+    wait_until(lambda: "hello there" in alice.text())
+
+    check_log(
+        bob.log_manager.log_dir / "localhost" / "server(2).log",
+        """
+
+*** LOGGING BEGINS <time>
+<time>  server  blah
+<time>  Bob     hello there
 """,
     )


### PR DESCRIPTION
Handles corner cases better and fixes #151.

Todo:
- [x] Add test where log file name conflict because of nicks, e.g. `{foo` and `}foo`