### PR TITLE
Make tests show up better on github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,8 +47,9 @@ jobs:
   pytest:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        # os is last so you can see the os in github's ui, even if the job name gets truncated
         irc-server: ["hircd", "mantatail"]
+        os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
         python-version: "3.9"  # can be 3.10 once mypy is updated and no longer really slow on 3.10
     - run: pip install -r requirements-dev.txt
     - run: mypy mantaray
-  pytest:
+  test:
     strategy:
       matrix:
         # os is last so you can see the os in github's ui, even if the job name gets truncated

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,7 +47,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # os is last so you can see the os in github's ui, even if the job name gets truncated
+        # os is last so you can see everything in github's ui, even if the job name gets truncated
         irc-server: ["hircd", "mantatail"]
         os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Space is tight in the UI, and the test names easily get truncated so much that you can't see what OS or IRC server the test is using.

Related: #180 