### PR TITLE
Show server's error messages to the user instead of hiding in server tab

### DIFF
--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -114,7 +114,6 @@ class ServerMessage:
     sender: str | None  # I think this is a hostname. Not sure.
     command: str  # e.g. '482'
     args: list[str]  # e.g. ["#foo", "You're not a channel operator"]
-    target_channel: str | None
     is_error: bool
 @dataclasses.dataclass
 class UnknownMessage:
@@ -380,18 +379,11 @@ class IrcCore:
                 channel, topic = msg.args[1:]
                 self._joining_in_progress[channel.lower()].topic = topic
 
-            target_channel = None
-            # TODO: remove startswith, its because https://github.com/ThePhilgrim/MantaTail/issues/83
-            if msg.command == "482" and msg.args[0].startswith("#"):
-                target_channel, *args = msg.args
-            else:
-                args = msg.args
             self.event_queue.put(
                 ServerMessage(
                     msg.sender,
                     msg.command,
-                    args,
-                    target_channel,
+                    msg.args,
                     # Errors seem to always be 4xx, 5xx or 7xx.
                     # Not all 6xx responses are errors, e.g. RPL_STARTTLS = 670
                     is_error=msg.command.startswith(("4", "5", "7")),

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -452,8 +452,25 @@ class ServerView(View):
                     ):
                         channel_view.add_notification(f"<{event.sender}> {event.text}")
 
-            elif isinstance(event, (backend.ServerMessage, backend.UnknownMessage)):
-                self.server_view.add_message(
+            elif isinstance(event, backend.ServerMessage):
+                if event.target_channel is not None:
+                    mypy_sucks = self.find_channel(event.target_channel)
+                    assert mypy_sucks is not None
+                    view = mypy_sucks
+                elif event.is_error:
+                    view = self.irc_widget.get_current_view()
+                else:
+                    view = self
+                view.add_message(
+                    event.sender or "???",
+                    (
+                        " ".join([event.command] + event.args),
+                        ["error"] if event.is_error else [],
+                    ),
+                )
+
+            elif isinstance(event, backend.UnknownMessage):
+                self.add_message(
                     event.sender or "???", (" ".join([event.command] + event.args), [])
                 )
 

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -455,11 +455,7 @@ class ServerView(View):
                         channel_view.add_notification(f"<{event.sender}> {event.text}")
 
             elif isinstance(event, backend.ServerMessage):
-                if event.target_channel is not None:
-                    mypy_sucks = self.find_channel(event.target_channel)
-                    assert mypy_sucks is not None
-                    view = mypy_sucks
-                elif event.is_error:
+                if event.is_error:
                     view = self.irc_widget.get_current_view()
                 else:
                     view = self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 skip-magic-trailing-comma = true
-exclude = '/tests/(hircd|mantatail)/'
+exclude = '/tests/(hircd|MantaTail)/'
 
 [tool.pytest.ini_options]
 addopts = "--capture=no --ignore=tests/MantaTail/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,8 +133,9 @@ def alice_and_bob(irc_server, root_window, wait_until, mocker):
             try:
                 # Fails sometimes on macos github actions, don't know yet why
                 wait_until(lambda: "The topic of #autojoin is" in widgets[name].text())
-            except RuntimeError:
-                raise RuntimeError(widgets[name].text())
+            except RuntimeError as e:
+                print(widgets[name].text())
+                raise e
 
         yield widgets
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,9 +130,11 @@ def alice_and_bob(irc_server, root_window, wait_until, mocker):
                 Path(tempfile.mkdtemp(prefix="mantaray-tests-")),
             )
             widgets[name].pack(fill="both", expand=True)
-            wait_until(
-                lambda: "The topic of #autojoin is" in widgets[name].text(), timeout=10
-            )
+            try:
+                # Fails sometimes on macos github actions, don't know yet why
+                wait_until(lambda: "The topic of #autojoin is" in widgets[name].text())
+            except RuntimeError:
+                raise RuntimeError(widgets[name].text())
 
         yield widgets
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -152,3 +152,14 @@ def test_incorrect_usage(alice, wait_until, command, error):
     alice.on_enter_pressed()
     wait_until(lambda: (error + "\n") in alice.text())
     assert alice.entry.get() == command  # give user chance to correct easily
+
+
+@pytest.mark.skipif(
+    os.environ["IRC_SERVER"] == "hircd",
+    reason="hircd doesn't support KICK and unknown commands fail tests",
+)
+def test_error_response(alice, wait_until):
+    alice.entry.insert("end", "/kick xyz")
+    alice.on_enter_pressed()
+    wait_until(lambda: alice.text().endswith("401 xyz No such nick/channel\n"))
+    assert "error" in alice.get_current_view().textwidget.tag_names("end - 10 chars")

--- a/tests/test_connection_errors.py
+++ b/tests/test_connection_errors.py
@@ -7,7 +7,9 @@ def test_clean_connect(alice):
     [server_view] = alice.get_server_views()
 
     # None of the messages sent during normal connecting should get tagged as error.
-    assert "error" in server_view.textwidget.tag_names()  # Fails if tags are renamed in refactoring
+    assert (
+        "error" in server_view.textwidget.tag_names()
+    )  # Fails if tags are renamed in refactoring
     assert not alice.get_server_views()[0].textwidget.tag_ranges("error")
 
 

--- a/tests/test_connection_errors.py
+++ b/tests/test_connection_errors.py
@@ -3,6 +3,14 @@ import sys
 import time
 
 
+def test_clean_connect(alice):
+    [server_view] = alice.get_server_views()
+
+    # None of the messages sent during normal connecting should get tagged as error.
+    assert "error" in server_view.textwidget.tag_names()  # Fails if tags are renamed in refactoring
+    assert not alice.get_server_views()[0].textwidget.tag_ranges("error")
+
+
 def test_quitting_while_disconnected(alice, irc_server, monkeypatch, wait_until):
     irc_server.process.kill()
     if sys.platform == "win32":


### PR DESCRIPTION
Fixes #138