### PR TITLE
improve wait_for_threads_to_stop

### DIFF
--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -159,6 +159,7 @@ class IrcCore:
         for thread in self._threads:
             thread.join(timeout=5)
             if thread.is_alive():
+                # TODO: hopefully this disgusting debug prints can remove some day
                 assert thread.ident is not None
                 stack_trace = traceback.format_stack(
                     sys._current_frames()[thread.ident]

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -159,8 +159,13 @@ class IrcCore:
         for thread in self._threads:
             thread.join(timeout=5)
             if thread.is_alive():
-                stack_trace = traceback.format_stack(sys._current_frames()[thread.ident])
-                raise RuntimeError(f"thread doesn't stop: {thread}\n" + "".join(stack_trace))
+                assert thread.ident is not None
+                stack_trace = traceback.format_stack(
+                    sys._current_frames()[thread.ident]
+                )
+                raise RuntimeError(
+                    f"thread doesn't stop: {thread}\n" + "".join(stack_trace)
+                )
 
     def _connect_and_recv_loop(self) -> None:
         while not self._quit_event.is_set():

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -8,6 +8,7 @@ import queue
 import ssl
 import re
 import socket
+import sys
 import threading
 import traceback
 from typing import Union, Sequence, Iterator
@@ -154,13 +155,12 @@ class IrcCore:
         for thread in self._threads:
             thread.start()
 
-    def wait_for_threads_to_stop(self, verbose: bool = False) -> None:
+    def wait_for_threads_to_stop(self) -> None:
         for thread in self._threads:
-            if verbose:
-                print("Waiting for thread to stop:", thread)
-            thread.join()
-        if verbose:
-            print("Threads stopped for", self.nick)
+            thread.join(timeout=5)
+            if thread.is_alive():
+                stack_trace = traceback.format_stack(sys._current_frames()[thread.ident])
+                raise RuntimeError(f"thread doesn't stop: {thread}\n" + "".join(stack_trace))
 
     def _connect_and_recv_loop(self) -> None:
         while not self._quit_event.is_set():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def alice_and_bob(irc_server, root_window, wait_until, mocker, irc_widgets_dict)
         for irc_widget in irc_widgets_dict.values():
             for server_view in irc_widget.get_server_views():
                 server_view.core.quit()
-                server_view.core.wait_for_threads_to_stop(verbose=True)
+                server_view.core.wait_for_threads_to_stop()
             # On windows, we need to wait until log files are closed before removing them
             wait_until(lambda: not irc_widget.winfo_exists())
             shutil.rmtree(irc_widget.log_manager.log_dir)


### PR DESCRIPTION
While debugging, I had the idea of printing a stack trace of a different thread. I also realized I can join with a timeout, so that if nothing freezes, no debugging info is printed.

Rewrites everything added in #223 