### PR TITLE
Keep track of own Usermask (nickmask)

### DIFF
--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -201,6 +201,9 @@ class IrcCore:
         self._events.clear()
         return result
 
+    def get_nickmask(self) -> str:
+        return self.nick + self.nickmask
+
     # Call this repeatedly from the GUI's event loop.
     #
     # This is the best we can do in tkinter without threading. I

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -227,6 +227,7 @@ class IrcCore:
             self._receive_buffer.clear()
             self.cap_req.clear()
             self.cap_list.clear()
+            self._nickmask = None
 
             self._events.append(
                 ConnectivityMessage(
@@ -255,7 +256,6 @@ class IrcCore:
 
             self._ping_sent = False
             self._last_receive_time = time.monotonic()
-            self._nickmask = None
 
             self._connection_state.setblocking(False)
 

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -135,6 +135,8 @@ class IrcCore:
         self.event_queue: queue.Queue[IrcEvent] = queue.Queue()
         self._thread: threading.Thread | None = None
 
+        self.nickmask = ""
+
     def _apply_config(self, server_config: config.ServerConfig) -> None:
         self.host = server_config["host"]
         self.port = server_config["port"]

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -202,6 +202,7 @@ class IrcCore:
         return result
 
     def get_nickmask(self) -> str:
+        assert self.nickmask is not None
         return self.nick + self.nickmask
 
     # Call this repeatedly from the GUI's event loop.

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -185,7 +185,7 @@ class IrcCore:
         self._ping_sent = False
         self._last_receive_time = time.monotonic()
 
-        self.nickmask: str | None = None
+        self._nickmask: str | None = None
 
     def _apply_config(self, server_config: config.ServerConfig) -> None:
         self.host = server_config["host"]
@@ -202,9 +202,9 @@ class IrcCore:
         return result
 
     def get_nickmask(self) -> str | None:
-        if self.nickmask is None:
+        if self._nickmask is None:
             return None
-        return self.nick + self.nickmask
+        return self.nick + self._nickmask
 
     # Call this repeatedly from the GUI's event loop.
     #
@@ -252,6 +252,7 @@ class IrcCore:
 
             self._ping_sent = False
             self._last_receive_time = time.monotonic()
+            self._nickmask = None
 
             self._connection_state.setblocking(False)
 

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -206,6 +206,9 @@ class IrcCore:
             return None
         return self.nick + self._nickmask
 
+    def set_nickmask(self, user: str, host: str) -> None:
+        self._nickmask = f"!{user}@{host}"
+
     # Call this repeatedly from the GUI's event loop.
     #
     # This is the best we can do in tkinter without threading. I

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -135,7 +135,7 @@ class IrcCore:
         self.event_queue: queue.Queue[IrcEvent] = queue.Queue()
         self._thread: threading.Thread | None = None
 
-        self.nickmask = ""
+        self.nickmask: str | None = None
 
     def _apply_config(self, server_config: config.ServerConfig) -> None:
         self.host = server_config["host"]

--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -201,8 +201,9 @@ class IrcCore:
         self._events.clear()
         return result
 
-    def get_nickmask(self) -> str:
-        assert self.nickmask is not None
+    def get_nickmask(self) -> str | None:
+        if self.nickmask is None:
+            return None
         return self.nick + self.nickmask
 
     # Call this repeatedly from the GUI's event loop.

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -598,7 +598,7 @@ def _handle_received_message(
 
     elif msg.command == RPL_WHOISUSER:
         if msg.args[0] == server_view.core.nick:
-            server_view.core.nickmask = f"{msg.args[1]}!{msg.args[2]}@{msg.args[3]}"
+            server_view.core.nickmask = f"!{msg.args[2]}@{msg.args[3]}"
     elif msg.command == RPL_WHOREPLY:
         _handle_whoreply(server_view, msg.args)
 

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -210,8 +210,6 @@ def _handle_nick(server_view: views.ServerView, old_nick: str, args: list[str]) 
             if isinstance(view, views.ChannelView):
                 view.userlist.change_nick(old_nick, new_nick)
 
-        server_view.core.send(f"WHOIS {new_nick}")
-
     else:
         for view in _get_views_relevant_for_nick(server_view, old_nick):
             view.add_message(
@@ -598,7 +596,7 @@ def _handle_received_message(
 
     elif msg.command == RPL_WHOISUSER:
         if msg.args[0] == server_view.core.nick:
-            server_view.core.nickmask = f"!{msg.args[2]}@{msg.args[3]}"
+            server_view.core._nickmask = f"!{msg.args[2]}@{msg.args[3]}"
     elif msg.command == RPL_WHOREPLY:
         _handle_whoreply(server_view, msg.args)
 

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -489,7 +489,8 @@ def _handle_received_message(
         _handle_numeric_rpl_topic(server_view, msg.args)
 
     elif msg.command == RPL_WHOISUSER:
-        server_view.core.nickmask = f"{msg.args[1]}!{msg.args[2]}@{msg.args[3]}"
+        if msg.args[0] == server_view.core.nick:
+            server_view.core.nickmask = f"{msg.args[1]}!{msg.args[2]}@{msg.args[3]}"
 
     elif msg.command == "TOPIC" and isinstance(msg, backend.MessageFromUser):
         _handle_literally_topic(server_view, msg.sender_nick, msg.args)

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -596,7 +596,7 @@ def _handle_received_message(
 
     elif msg.command == RPL_WHOISUSER:
         if msg.args[0] == server_view.core.nick:
-            server_view.core._nickmask = f"!{msg.args[2]}@{msg.args[3]}"
+            server_view.core.set_nickmask(user=msg.args[2], host=msg.args[3])
     elif msg.command == RPL_WHOREPLY:
         _handle_whoreply(server_view, msg.args)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,7 @@ def irc_server():
         output = (
             output.replace(b"BrokenPipeError:", b"")
             .replace(b"ConnectionAbortedError: [WinError 10053]", b"")
+            .replace(b"[ERROR] :localhost 421 WHOIS :Unknown command", b"")
             .replace(b"ConnectionResetError: [Errno 54]", b"")
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,30 +224,30 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     assert "quit" not in bob.text()
 
 
-# Neither Mantatail nor Hircd currently supports the WHOIS command.
-# IrcCore.nickmask will therefore always be "" in the test.
+# Hircd currently doesn't support the WHOIS command
+# IrcCore._nickmask will therefore always be None in the test.
 @pytest.mark.skipif(
     os.environ["IRC_SERVER"] == "hircd", reason="hircd sends QUIT twice"
 )
 @pytest.mark.xfail
 def test_generate_nickmask(alice, mocker, wait_until):
     server_view = alice.get_server_views()[0]
-    assert alice.server_view.core.nickmask == "Alice!AliceUsr@localhost"
+    assert alice.server_view.core._nickmask == "Alice!AliceUsr@localhost"
 
     alice.entry.insert("end", "/nick Foo")
     alice.on_enter_pressed()
 
-    assert alice.server_view.core.nickmask == "Foo!AliceUsr@localhost"
+    assert alice.server_view.core._nickmask == "Foo!AliceUsr@localhost"
 
     reconnect_with_change(server_view, mocker, "username", old="AliceUsr", new="FooUsr")
     wait_until(lambda: alice.text().count("The topic of #autojoin is:") == 2)
 
-    assert alice.server_view.core.nickmask == "Foo!FooUsr@localhost"
+    assert alice.server_view.core._nickmask == "Foo!FooUsr@localhost"
 
     reconnect_with_change(server_view, mocker, "host", old="localhost", new="127.0.0.1")
     wait_until(lambda: alice.text().count("The topic of #autojoin is:") == 3)
 
-    assert alice.server_view.core.nickmask == "Foo!FooUsr@127.0.0.1"
+    assert alice.server_view.core._nickmask == "Foo!FooUsr@127.0.0.1"
 
 
 def test_autojoin(alice, wait_until, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,26 +224,33 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     assert "quit" not in bob.text()
 
 
-@pytest.mark.skipif(
-    os.environ["IRC_SERVER"] == "hircd",
-    reason="Hircd currently doesn't support the WHOIS command. IrcCore._nickmask will therefore always be None in the test.",
-)
 def test_generate_nickmask(alice, mocker, wait_until):
-
     server_view = alice.get_server_views()[0]
-    assert server_view.core.get_nickmask() == "Alice!AliceUsr@127.0.0.1"
+
+    if (
+        os.environ["IRC_SERVER"] == "hircd"
+    ):  # Hircd does not support the WHOIS command. Nickmask will therefore always be None.
+        assert server_view.core.get_nickmask() is None
+    else:
+        assert server_view.core.get_nickmask() == "Alice!AliceUsr@127.0.0.1"
 
     alice.entry.insert("end", "/nick Foo")
     alice.on_enter_pressed()
 
     wait_until(lambda: "You are now known as Foo" in alice.text())
-    assert server_view.core.get_nickmask() == "Foo!AliceUsr@127.0.0.1"
+    if os.environ["IRC_SERVER"] == "hircd":
+        assert server_view.core.get_nickmask() is None
+    else:
+        assert server_view.core.get_nickmask() == "Foo!AliceUsr@127.0.0.1"
 
     reconnect_with_change(server_view, mocker, "username", old="AliceUsr", new="FooUsr")
 
     wait_until(lambda: alice.text().count("The topic of #autojoin is:") == 2)
 
-    assert server_view.core.get_nickmask() == "Foo!FooUsr@127.0.0.1"
+    if os.environ["IRC_SERVER"] == "hircd":
+        assert server_view.core.get_nickmask() is None
+    else:
+        assert server_view.core.get_nickmask() == "Foo!FooUsr@127.0.0.1"
 
 
 def test_autojoin(alice, wait_until, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,6 +177,9 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
 
 # Neither Mantatail nor Hircd currently supports the WHOIS command.
 # IrcCore.nickmask will therefore always be "" in the test.
+@pytest.mark.skipif(
+    os.environ["IRC_SERVER"] == "hircd", reason="hircd sends QUIT twice"
+)
 @pytest.mark.xfail
 def test_generate_nickmask(alice, mocker, wait_until):
     server_view = alice.get_server_views()[0]


### PR DESCRIPTION
This is a slightly hacky way to keep track of the usermask (which is actually called nickmask according to the Horse docs). It relies on sending a `WHOIS own_nick` to the server which then always replies with all components of the nickmask in `311 RPL_WHOISUSER`.

Ex:
```
Sent – WHOIS fubbe
Received – :copper.libera.chat 311 Fubbe Fubbe ~IAmTheFub 151.40.115.120 * :lol <---------
Received – :copper.libera.chat 312 Fubbe Fubbe copper.libera.chat :Sofia, BG
Received – :copper.libera.chat 338 Fubbe Fubbe 151.40.115.120 :actually using host
Received – :copper.libera.chat 317 Fubbe Fubbe 6 1644854035 :seconds idle, signon time
Received – :copper.libera.chat 318 Fubbe fubbe :End of /WHOIS list.
```

This should help to make it easier solving #172 (in a separate PR). This code would have to check if `server_view.core.nickmask != ""` to make sure the messages are not cut off incorrectly. However, most respectable IRC servers support `WHOIS`

Ex Freenode:
```
WHOIS fubbe
:teepee.freenode.net 311 fubbe fubbe ~bubbe joseon-8tr.tfj.n3gjid.IP * :lol
```

Of course, this logic can be substituted for something like `USERLEN` if Libera ever implements it, or if we find something else that would be a more elegant solution.

Right now, the test xfails. This is because neither Mantatail nor Hircd support `WHOIS`. This is noted in https://github.com/ThePhilgrim/MantaTail/issues/128

If you feel that this is not a good enough solution, feel free to close.

