### PR TITLE
Put error messages to all views

### DIFF
--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -486,6 +486,7 @@ def _handle_unknown_message(
         ("4", "5", "7")
     ):
         server_view.irc_widget.get_current_view().add_message(text, sender, tag="error")
+        server_view.add_message(text, sender, tag="error")
     else:
         server_view.add_message(text, sender)
 

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -485,10 +485,8 @@ def _handle_unknown_message(
     if isinstance(msg, backend.MessageFromServer) and msg.command.startswith(
         ("4", "5", "7")
     ):
-        server_view.add_message(text, sender, tag="error")
-        current_view = server_view.irc_widget.get_current_view()
-        if current_view != server_view:
-            current_view.add_message(text, sender, tag="error")
+        for view in server_view.get_subviews(include_server=True):
+            view.add_message(text, sender, tag="error")
     else:
         server_view.add_message(text, sender)
 

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -485,8 +485,10 @@ def _handle_unknown_message(
     if isinstance(msg, backend.MessageFromServer) and msg.command.startswith(
         ("4", "5", "7")
     ):
-        server_view.irc_widget.get_current_view().add_message(text, sender, tag="error")
         server_view.add_message(text, sender, tag="error")
+        current_view = server_view.irc_widget.get_current_view()
+        if current_view != server_view:
+            current_view.add_message(text, sender, tag="error")
     else:
         server_view.add_message(text, sender)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -120,7 +120,8 @@ def test_kick(alice, bob, wait_until):
 
     bob.entry.insert(0, "just trying to talk here...")
     bob.on_enter_pressed()
-    wait_until(lambda: bob.text().endswith("#autojoin You're not on that channel\n"))
+    wait_until(lambda: "#autojoin You're not on that channel" in bob.text())
+    wait_until(lambda: "#autojoin You're not on that channel" in bob.get_server_views()[0].get_text())
 
     alice.view_selector.selection_set(alice.get_server_views()[0].view_id)
     alice.entry.insert("end", "/kick bob")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -120,13 +120,8 @@ def test_kick(alice, bob, wait_until):
 
     bob.entry.insert(0, "just trying to talk here...")
     bob.on_enter_pressed()
-    wait_until(lambda: "#autojoin You're not on that channel" in bob.text())
-    wait_until(
-        lambda: (
-            "#autojoin You're not on that channel"
-            in bob.get_server_views()[0].get_text()
-        )
-    )
+    for view in bob.views_by_id.values():
+        wait_until(lambda: "#autojoin You're not on that channel" in view.get_text())
 
     alice.view_selector.selection_set(alice.get_server_views()[0].view_id)
     alice.entry.insert("end", "/kick bob")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -121,7 +121,10 @@ def test_kick(alice, bob, wait_until):
     bob.entry.insert(0, "just trying to talk here...")
     bob.on_enter_pressed()
     wait_until(lambda: "#autojoin You're not on that channel" in bob.text())
-    wait_until(lambda: "#autojoin You're not on that channel" in bob.get_server_views()[0].get_text())
+    wait_until(
+        lambda: "#autojoin You're not on that channel"
+        in bob.get_server_views()[0].get_text()
+    )
 
     alice.view_selector.selection_set(alice.get_server_views()[0].view_id)
     alice.entry.insert("end", "/kick bob")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -122,8 +122,10 @@ def test_kick(alice, bob, wait_until):
     bob.on_enter_pressed()
     wait_until(lambda: "#autojoin You're not on that channel" in bob.text())
     wait_until(
-        lambda: "#autojoin You're not on that channel"
-        in bob.get_server_views()[0].get_text()
+        lambda: (
+            "#autojoin You're not on that channel"
+            in bob.get_server_views()[0].get_text()
+        )
     )
 
     alice.view_selector.selection_set(alice.get_server_views()[0].view_id)


### PR DESCRIPTION
Was confusing when the "you were redirected from #foo to #bar" error showed up in a completely unrelated channel, only because that happened to be the current channel during the autojoining.