### PR TITLE
Send the next WHO only after the previous WHO reply ends

### DIFF
--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -416,6 +416,8 @@ def _handle_namreply(server_view: views.ServerView, args: list[str]) -> None:
 # While waiting for a response to a WHO, don't send another WHO.
 # This prevents the server from deciding to disconnect because it's
 # being asked to send a lot of data quickly.
+#
+# TODO: clear this when reconnecting
 _pending_who_sends: dict[views.ServerView, list[str]] = {}
 
 

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -455,9 +455,7 @@ def _handle_whoreply(server_view: views.ServerView, args: list[str]) -> None:
         view.userlist.set_away(nick, True)
 
 
-def _handle_endofwho(
-    server_view: views.ServerView
-) -> None:
+def _handle_endofwho(server_view: views.ServerView) -> None:
     if _pending_who_sends[server_view]:
         channel = _pending_who_sends[server_view].pop()
         server_view.core.send(f"WHO {channel}")


### PR DESCRIPTION
Fixes #238. Filtering the output of `--verbose` to only the lines that contain `WHO`, I get this on libera when I connect:

```
Send: b'WHO #c\r\n'
Recv: b':strontium.libera.chat 315 Akuli #c :End of /WHO list.\r\n'
Send: b'WHO #devuan-offtopic\r\n'
Recv: b':strontium.libera.chat 315 Akuli #devuan-offtopic :End of /WHO list.\r\n'
Send: b'WHO #devuan\r\n'
Recv: b':strontium.libera.chat 315 Akuli #devuan :End of /WHO list.\r\n'
Send: b'WHO #ircv3\r\n'
Recv: b':strontium.libera.chat 315 Akuli #ircv3 :End of /WHO list.\r\n'
Send: b'WHO #8banana\r\n'
Recv: b':strontium.libera.chat 315 Akuli #8banana :End of /WHO list.\r\n'
Send: b'WHO ##akuli-testing\r\n'
Recv: b':strontium.libera.chat 315 Akuli ##akuli-testing :End of /WHO list.\r\n'
Send: b'WHO ##guitar\r\n'
Recv: b':strontium.libera.chat 315 Akuli ##guitar :End of /WHO list.\r\n'
Send: b'WHO #tcl\r\n'
Recv: b':strontium.libera.chat 315 Akuli #tcl :End of /WHO list.\r\n'
Send: b'WHO ##programming\r\n'
Recv: b':strontium.libera.chat 315 Akuli ##programming :End of /WHO list.\r\n'
Send: b'WHO #libera\r\n'
Recv: b':strontium.libera.chat 315 Akuli #libera :End of /WHO list.\r\n'
Send: b'WHO #mantaray\r\n'
Recv: b':strontium.libera.chat 315 Akuli #mantaray :End of /WHO list.\r\n'
Send: b'WHO ##learnmath\r\n'
Recv: b':strontium.libera.chat 315 Akuli ##learnmath :End of /WHO list.\r\n'
Send: b'WHO ##learnpython\r\n'
Recv: b':strontium.libera.chat 315 Akuli ##learnpython :End of /WHO list.\r\n'
```

Also fixes #246.