### PR TITLE
add test for not an operator error while changing topic

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -93,6 +93,12 @@ def test_topic_change(alice, bob, wait_until):
     bob.on_enter_pressed()
     wait_until(lambda: "The topic of #autojoin is: blah blah\n" in bob.text())
 
+    bob.entry.insert(0, "/topic blah blah")
+    bob.on_enter_pressed()
+    wait_until(
+        lambda: "482 Bob #autojoin You're not channel operator" in bob.text()
+    )
+
 
 @pytest.mark.skipif(
     os.environ["IRC_SERVER"] == "hircd", reason="hircd doesn't support KICK"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -95,9 +95,7 @@ def test_topic_change(alice, bob, wait_until):
 
     bob.entry.insert(0, "/topic blah blah")
     bob.on_enter_pressed()
-    wait_until(
-        lambda: "482 Bob #autojoin You're not channel operator" in bob.text()
-    )
+    wait_until(lambda: "482 Bob #autojoin You're not channel operator" in bob.text())
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #53. It was already fixed in #249, but now there's a test for the fix too.