### PR TITLE
hide nickserv passwords

### DIFF
--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -610,7 +610,10 @@ def handle_event(event: backend.IrcEvent, server_view: views.ServerView) -> None
 
             # /msg NickServ identify <password>   --> hide password
             text = event.text
-            if pm_view.nick_of_other_user.lower() == "nickserv" and text.lower().startswith("identify "):
+            if (
+                pm_view.nick_of_other_user.lower() == "nickserv"
+                and text.lower().startswith("identify ")
+            ):
                 text = text[:9] + "********"
 
             _add_privmsg_to_view(

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -607,8 +607,14 @@ def handle_event(event: backend.IrcEvent, server_view: views.ServerView) -> None
                 # start of a new PM conversation
                 pm_view = views.PMView(server_view, event.nick_or_channel)
                 server_view.irc_widget.add_view(pm_view)
+
+            # /msg NickServ identify <password>   --> hide password
+            text = event.text
+            if pm_view.nick_of_other_user.lower() == "nickserv" and text.lower().startswith("identify "):
+                text = text[:9] + "********"
+
             _add_privmsg_to_view(
-                pm_view, server_view.core.nick, event.text, history_id=event.history_id
+                pm_view, server_view.core.nick, text, history_id=event.history_id
             )
         else:
             _add_privmsg_to_view(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -223,10 +223,18 @@ def test_nickserv_and_memoserv(alice, bob, wait_until):
     bob.get_server_views()[0].core.send("NICK NickServ")
     wait_until(lambda: "You are now known as NickServ.\n" in bob.text())
 
-    # FIXME: show password with *** in Alice's client?
-    alice.entry.insert(0, "/ns identify Alice hunter2")
+    # Password is shown with *** in Alice's client, nickserv commands are case insensitive
+    alice.entry.insert(0, "/ns IdEnTiFy Alice hunter2")
     alice.on_enter_pressed()
-    wait_until(lambda: "identify Alice hunter2\n" in bob.text())
+    wait_until(lambda: "IdEnTiFy ********\n" in alice.text())
+    assert "hunter2" not in alice.text()
+
+    text = (alice.log_manager.log_dir / "localhost" / "nickserv.log").read_text("utf-8")
+    assert "identify ********" in text
+    assert "hunter2" not in text
+
+    # It does not actually send the stars though, lol. So Bob sees the password
+    wait_until(lambda: "IdEnTiFy Alice hunter2\n" in bob.text())
     assert bob.get_current_view().nick_of_other_user == "Alice"
 
     bob.get_server_views()[0].core.send("NICK MemoServ")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -218,7 +218,7 @@ def test_command_cant_contain_multiple_slashes(alice, bob, wait_until):
     wait_until(lambda: "/home/alice" in bob.text())
 
 
-def test_nickserv_and_memoserv(alice, bob, wait_until):
+def test_nickserv(alice, bob, wait_until):
     # Bob shall pretend he is nickserv, because hircd and mantatail don't have nickserv
     bob.get_server_views()[0].core.send("NICK NickServ")
     wait_until(lambda: "You are now known as NickServ.\n" in bob.text())
@@ -230,13 +230,15 @@ def test_nickserv_and_memoserv(alice, bob, wait_until):
     assert "hunter2" not in alice.text()
 
     text = (alice.log_manager.log_dir / "localhost" / "nickserv.log").read_text("utf-8")
-    assert "identify ********" in text
+    assert "IdEnTiFy ********" in text
     assert "hunter2" not in text
 
     # It does not actually send the stars though, lol. So Bob sees the password
     wait_until(lambda: "IdEnTiFy Alice hunter2\n" in bob.text())
     assert bob.get_current_view().nick_of_other_user == "Alice"
 
+
+def test_memoserv(alice, bob, wait_until):
     bob.get_server_views()[0].core.send("NICK MemoServ")
     wait_until(lambda: "You are now known as MemoServ.\n" in bob.text())
 


### PR DESCRIPTION
Fixes #64 

I no longer use nickserv, because mantaray makes using SASL authentication so easy. But if someone is stuck with nickserv, we might as well not punish them by saving their password to the log file every time they log in.