### PR TITLE
tests: pipe irc server output to file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,9 +88,9 @@ def switch_view():
 
 
 class _IrcServer:
-    def __init__(self, log_file):
+    def __init__(self, output_file):
         self.process = None
-        self._log_file = log_file
+        self._output_file = output_file
 
     def start(self):
         # Make sure that prints appear right away
@@ -130,8 +130,8 @@ class _IrcServer:
 
         self.process = subprocess.Popen(
             command,
-            stdout=self._log_file,
-            stderr=self._log_file,
+            stdout=self._output_file,
+            stderr=self._output_file,
             env=env,
             cwd=working_dir,
         )
@@ -149,7 +149,7 @@ class _IrcServer:
 @pytest.fixture
 def irc_server():
     with tempfile.TemporaryFile() as output_file:
-        server = _IrcServer()
+        server = _IrcServer(output_file)
         try:
             server.start()
             yield server
@@ -160,14 +160,14 @@ def irc_server():
         output_file.seek(0)
         output = output_file.read()
 
-#    if os.environ["IRC_SERVER"] == "hircd":
-#        # A bit of a hack, but I don't care about disconnect errors
-#        output = (
-#            output.replace(b"BrokenPipeError:", b"")
-#            .replace(b"ConnectionAbortedError: [WinError 10053]", b"")
-#            .replace(b"ConnectionResetError: [Errno 54]", b"")
-#            .replace(b"[ERROR] :localhost 421 CAP :Unknown command", b"")
-#        )
+    if os.environ["IRC_SERVER"] == "hircd":
+        # A bit of a hack, but I don't care about disconnect errors
+        output = (
+            output.replace(b"BrokenPipeError:", b"")
+            .replace(b"ConnectionAbortedError: [WinError 10053]", b"")
+            .replace(b"ConnectionResetError: [Errno 54]", b"")
+            .replace(b"[ERROR] :localhost 421 CAP :Unknown command", b"")
+        )
 
     if b"error" in output.lower():
         print(output.decode("utf-8", errors="replace"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ class _IrcServer:
         time_limit = time.monotonic() + 5
         while True:
             try:
-                socket.create_connection(('localhost', 6667)).close()
+                socket.create_connection(("localhost", 6667)).close()
                 break
             except ConnectionRefusedError:
                 assert time.monotonic() < time_limit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,7 @@ def irc_server():
         output = (
             output.replace(b"BrokenPipeError:", b"")
             .replace(b"ConnectionAbortedError: [WinError 10053]", b"")
+            .replace(b"ConnectionResetError: [WinError 10054]", b"")
             .replace(b"ConnectionResetError: [Errno 54]", b"")
             .replace(b"[ERROR] :localhost 421 CAP :Unknown command", b"")
         )


### PR DESCRIPTION
Reading the pipe after each test finished worked well, until the operating system's buffer became full, and hircd stopped working while it was stuck printing. I believe this is what causes CI in #244 to error.