### PR TITLE
Delete pyflakes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,16 +14,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         grep $(date +%Y) LICENSE
-  pyflakes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - run: pip install -r requirements-dev.txt
-    - run: pyflakes mantaray tests
   mypy:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 black==22.6.0
 isort==5.11.5
 pycln==2.1.3
-pyflakes==2.4.0
 mypy==0.971
 types-appdirs==1.4.2
 pytest==6.2.5


### PR DESCRIPTION
Main reason to have it was to complain about unused imports, but now `pycln` does that. For anything else I trust my editor (Porcupine) to run pyflakes.