### PR TITLE
Simplify how nick name remembering works

### DIFF
--- a/mantaray/backend.py
+++ b/mantaray/backend.py
@@ -149,17 +149,8 @@ class IrcCore:
         self.settings = settings
         self._verbose = verbose
 
-        # The nick stored in self is the actual nick that the user has right now.
-        # The nick in settings represents what the user would like to have.
-        #
-        # These can be different if the server changes the user's nick to something
-        # like Guest1234. Also in the future we might handle nick name in use errors
-        # by trying f"{settings.nick}_" or similar.
-        self.nick = settings.nick
-
-        # Similar to nick this is where we are actually connected to.
-        # Most of the time this is same as settings.host, because we
-        # reconnect shortly after changing the host in settings.
+        # This is where we are actually connected to. When the settings
+        # change, we reconnect shortly after and that's when this updates.
         self.host = settings.host
 
         self._send_queue: collections.deque[
@@ -210,7 +201,7 @@ class IrcCore:
     def get_nickmask(self) -> str | None:
         if self._nickmask is None:
             return None
-        return self.nick + self._nickmask
+        return self.settings.nick + self._nickmask
 
     def set_nickmask(self, user: str, host: str) -> None:
         self._nickmask = f"!{user}@{host}"
@@ -278,7 +269,7 @@ class IrcCore:
             for capability in self.cap_req:
                 self.send(f"CAP REQ {capability}")
 
-            self.send(f"NICK {self.nick}")
+            self.send(f"NICK {self.settings.nick}")
             self.send(f"USER {self.settings.username} 0 * :{self.settings.realname}")
 
         else:

--- a/mantaray/commands.py
+++ b/mantaray/commands.py
@@ -110,7 +110,6 @@ def _define_commands() -> dict[str, Callable[..., None]]:
 
     def nick(view: View, core: IrcCore, new_nick: str) -> None:
         core.send(f"NICK :{new_nick}")
-        view.server_view.settings.nick = new_nick
 
     def topic(view: View, core: IrcCore, new_topic: str) -> None:
         if isinstance(view, ChannelView):

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -172,10 +172,9 @@ class IrcWidget(ttk.PanedWindow):
 
     def _show_change_nick_dialog(self) -> None:
         server_view = self.get_current_view().server_view
-        new_nick = ask_new_nick(self.winfo_toplevel(), server_view.core.nick)
-        if new_nick != server_view.core.nick:
+        new_nick = ask_new_nick(self.winfo_toplevel(), server_view.settings.nick)
+        if new_nick != server_view.settings.nick:
             server_view.core.send(f"NICK {new_nick}")
-            server_view.settings.nick = new_nick
 
     def on_enter_pressed(self, junk_event: object = None) -> None:
         view = self.get_current_view()
@@ -331,7 +330,7 @@ class IrcWidget(ttk.PanedWindow):
 
         self._previous_view = new_view
 
-        self.nickbutton.config(text=new_view.server_view.core.nick)
+        self.nickbutton.config(text=new_view.server_view.settings.nick)
 
     def add_view(self, view: View) -> None:
         assert view.view_id not in self.views_by_id

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -210,6 +210,7 @@ def _handle_nick(server_view: views.ServerView, old_nick: str, args: list[str]) 
         # settings as soon as it changes, you need to separately keep track of the
         # nick that is currently being used.
         server_view.settings.nick = new_nick
+        server_view.settings.save()
         if server_view.irc_widget.get_current_view().server_view == server_view:
             server_view.irc_widget.nickbutton.config(text=new_nick)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,12 +102,10 @@ class _IrcServer:
         self._output_file = output_file
 
     def start(self):
-        try:
-            socket.create_connection(("localhost", 6667)).close()
-        except ConnectionRefusedError:
-            pass
-        else:
-            raise RuntimeError("an IRC server is already running on port 6667")
+        if _port_6667_is_in_use():
+            raise RuntimeError(
+                "an IRC server (or something else) is already running on port 6667"
+            )
 
         # Make sure that prints appear right away
         env = dict(os.environ)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ def irc_server():
         finally:
             if server.process is not None:
                 server.process.kill()
+                server.process.wait(timeout=5)
             output_file.seek(0)
             output = output_file.read()
             if is_error:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -248,20 +248,14 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
     assert "quit" not in bob.text()
 
 
-def test_nick_change_saved(alice, mocker):
-    # Settings update immediately, so that even if the nick is not available,
-    # mantaray will try to use that nick later.
-    #
-    # TODO: This only makes sense if we try other nicks when a nick is in use,
-    #       but that isn't implemented yet.
-
+def test_nick_change_saved(alice, mocker, wait_until):
     alice.entry.insert(0, "/nick foo")
     alice.on_enter_pressed()
-    assert alice.get_server_views()[0].settings.nick == "foo"
+    wait_until(lambda: alice.get_server_views()[0].settings.nick == "foo")
 
     mocker.patch("mantaray.gui.ask_new_nick", return_value="bar")
     alice.nickbutton.invoke()
-    assert alice.get_server_views()[0].settings.nick == "bar"
+    wait_until(lambda: alice.get_server_views()[0].settings.nick == "bar")
 
 
 def test_generate_nickmask(alice, mocker, wait_until):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,12 +251,16 @@ def test_join_part_quit_messages_disabled(alice, bob, wait_until, monkeypatch):
 
 
 def test_nick_change_saved(alice, mocker, wait_until):
+    # New nick is saved to settings when the server says that changing nick succeeded.
+    # This way, if changing nick fails (e.g. already in use), nothing will happen.
     alice.entry.insert(0, "/nick foo")
     alice.on_enter_pressed()
+    assert alice.get_server_views()[0].settings.nick == "Alice"
     wait_until(lambda: alice.get_server_views()[0].settings.nick == "foo")
 
     mocker.patch("mantaray.gui.ask_new_nick", return_value="bar")
     alice.nickbutton.invoke()
+    assert alice.get_server_views()[0].settings.nick == "foo"
     wait_until(lambda: alice.get_server_views()[0].settings.nick == "bar")
 
 


### PR DESCRIPTION
New logic is super simple: Keep track of the current nick in only one place, the settings. When you attempt to change the nick, nothing happens immediately. When the server tells you that your nick is now xyz, the settings updates and next time Mantaray sends `NICK xyz` when it starts.