### PR TITLE
Add a /raw command

### DIFF
--- a/mantaray/commands.py
+++ b/mantaray/commands.py
@@ -163,6 +163,9 @@ def _define_commands() -> dict[str, Callable[..., None]]:
     def back(view: View, core: IrcCore) -> None:
         core.send("AWAY")
 
+    def raw(view: View, core: IrcCore, command: str) -> None:
+        core.send(command)
+
     return {
         "/join": join,
         "/part": part,
@@ -181,6 +184,7 @@ def _define_commands() -> dict[str, Callable[..., None]]:
         "/kick": kick,
         "/away": away,
         "/back": back,
+        "/raw": raw,
     }
 
 


### PR DESCRIPTION
This makes it possible to use commands that mantaray doesn't officially support yet. For example, `/raw NICK foo` is equivalent to `/nick foo`.