### PR TITLE
/whois

### DIFF
--- a/mantaray/commands.py
+++ b/mantaray/commands.py
@@ -136,6 +136,9 @@ def _define_commands() -> dict[str, Callable[..., None]]:
     def msg_chanserv(view: View, core: IrcCore, message: str) -> None:
         return msg(view, core, "ChanServ", message)
 
+    def whois(view: View, core: IrcCore, nick: str) -> None:
+        core.send(f"WHOIS {nick}")
+
     def op(view: View, core: IrcCore, nick: str) -> None:
         if isinstance(view, ChannelView):
             core.send(f"MODE {view.channel_name} +o :{nick}")
@@ -179,6 +182,7 @@ def _define_commands() -> dict[str, Callable[..., None]]:
         "/memoserv": msg_memoserv,
         "/cs": msg_chanserv,
         "/chanserv": msg_chanserv,
+        "/whois": whois,
         "/op": op,
         "/deop": deop,
         "/kick": kick,

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -455,6 +455,7 @@ def _handle_whois_reply(server_view: views.ServerView, msg: backend.MessageFromS
         text = f"{msg.command} {nick} {' '.join(msg.args[2:])}"
 
     if nick == server_view.settings.nick:
+        # This is a reply to running WHOIS on the current user.
         if msg.command == RPL_WHOISUSER:
             server_view.core.set_nickmask(user=msg.args[2], host=msg.args[3])
         server_view.add_message(text)

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -444,7 +444,7 @@ def _handle_numeric_rpl_topic(server_view: views.ServerView, args: list[str]) ->
     join.topic = topic
 
 
-def _handle_whois_reply(server_view: views.ServerView, msg: backend.MessageFromServer):
+def _handle_whois_reply(server_view: views.ServerView, msg: backend.MessageFromServer) -> None:
     nick = msg.args[1]
 
     if msg.command == RPL_WHOISACCOUNT:

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -444,7 +444,9 @@ def _handle_numeric_rpl_topic(server_view: views.ServerView, args: list[str]) ->
     join.topic = topic
 
 
-def _handle_whois_reply(server_view: views.ServerView, msg: backend.MessageFromServer) -> None:
+def _handle_whois_reply(
+    server_view: views.ServerView, msg: backend.MessageFromServer
+) -> None:
     nick = msg.args[1]
 
     if msg.command == RPL_WHOISACCOUNT:

--- a/mantaray/right_click_menus.py
+++ b/mantaray/right_click_menus.py
@@ -98,8 +98,18 @@ def channel_view_right_click(event: _AnyEvent, view: ChannelView) -> None:
     _show_menu(menu, event)
 
 
+def _add_whois(menu: tkinter.Menu, server_view: ServerView, nick: str) -> None:
+    menu.add_command(
+        label=f"Show user info (/whois {nick})",
+        command=(lambda: server_view.core.send(f"WHOIS {nick}")),
+        # Discourage running /whois on the current user
+        state=("disabled" if nick == server_view.settings.nick else "normal"),
+    )
+
+
 def pm_view_right_click(event: _AnyEvent, view: PMView) -> None:
     menu = get_menu(clear=True)
+    _add_whois(menu, view.server_view, view.nick_of_other_user)
     menu.add_command(label="Close", command=(lambda: view.irc_widget.remove_view(view)))
     _show_menu(menu, event)
 
@@ -107,7 +117,8 @@ def pm_view_right_click(event: _AnyEvent, view: PMView) -> None:
 def nick_right_click(event: _AnyEvent, server_view: ServerView, nick: str) -> None:
     menu = get_menu(clear=True)
     menu.add_command(
-        label=f"Send private message to {nick}",
+        label=f"Send a private message to {nick}",
         command=(lambda: server_view.find_or_open_pm(nick, select_existing=True)),
     )
+    _add_whois(menu, server_view, nick)
     _show_menu(menu, event)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,8 +1,9 @@
-import os,re
+import os
+import re
 
 import pytest
 
-from mantaray.views import ServerView,PMView
+from mantaray.views import PMView, ServerView
 
 # https://stackoverflow.com/a/30575822
 params = ["/part", "/part #lol"]
@@ -149,7 +150,7 @@ def test_me(alice, bob, wait_until):
 @pytest.mark.skipif(
     os.environ["IRC_SERVER"] == "hircd", reason="hircd doesn't support WHOIS"
 )
-def test_whois(alice, bob,wait_until):
+def test_whois(alice, bob, wait_until):
     alice.entry.insert(0, "/whois bob")
     alice.on_enter_pressed()
     wait_until(lambda: "End of /WHOIS list." in alice.text())


### PR DESCRIPTION
Fixes #97 
Checks a box in #304 

Kinda helps with #287. When you run `/whois` on someone who is away, their away reason shows up in the server view. It's not ideal though. I will probably add away reason displaying somewhere else in the GUI as well.