### PR TITLE
Use light theme in "python3 -m mantaray --alice"

### DIFF
--- a/alice/config.json
+++ b/alice/config.json
@@ -1,4 +1,5 @@
 {
+  "theme": "light",
   "servers": [
     {
       "host": "localhost",


### PR DESCRIPTION
This will hopefully prevent forgetting the light theme when I change something. I like to use

```
python3 -m mantaray --alice & python3 -m mantaray --bob &
```

when developing, with an IRC server (`python3 server.py` in MantaTail) running in a separate terminal.