### PR TITLE
Specifying away status by clicking nick button

### DIFF
--- a/mantaray/commands.py
+++ b/mantaray/commands.py
@@ -162,7 +162,8 @@ def _define_commands() -> dict[str, Callable[..., None]]:
 
     def away(view: View, core: IrcCore, away_message: str) -> None:
         core.send(f"AWAY :{away_message}")
-        view.server_view.last_away_status = away_message
+        view.server_view.settings.last_away_status = away_message
+        view.server_view.settings.save()
 
     def back(view: View, core: IrcCore) -> None:
         core.send("AWAY")

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -129,10 +129,10 @@ class ServerSettings:
             "join_leave_hiding", {"show_by_default": True, "exception_nicks": []}
         )
         self.audio_notification: bool = dict_from_file.get("audio_notification", False)
-        # last_away_status is never empty
         self.last_away_status: str = dict_from_file.get("last_away_status", "Away")
 
     def get_json(self) -> dict[str, Any]:
+        assert self.last_away_status  # should never be empty
         return {
             "host": self.host,
             "port": self.port,

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -67,6 +67,7 @@ class Settings:
                     "join_leave_hiding",
                     {"show_by_default": True, "exception_nicks": []},
                 )
+                server_dict.setdefault("last_away_status", "Away")
 
                 self.servers.append(
                     ServerSettings(
@@ -110,50 +111,27 @@ class JoinLeaveHidingSettings(TypedDict):
 
 
 class ServerSettings:
-    host: str
-    port: int
-    ssl: bool
-    nick: str  # TODO: multiple choices, in case already in use
-    username: str
-    realname: str
-    password: str | None
-    joined_channels: list[str]
-    extra_notifications: set[str]  # channel names to notify for all messages
-    join_leave_hiding: JoinLeaveHidingSettings
-    audio_notification: bool
-
     def __init__(
         self,
         parent_settings_object: Settings | None = None,
-        dict_from_file: dict[str, Any] | None = None,
+        dict_from_file: dict[str, Any] = {},
     ) -> None:
         self.parent_settings_object = parent_settings_object
 
-        if dict_from_file is None:
-            # This is what the user sees when running Mantaray for the first time
-            self.host = "irc.libera.chat"
-            self.port = 6697
-            self.ssl = True
-            self.nick = getuser()
-            self.username = getuser()
-            self.realname = getuser()
-            self.password = None
-            self.joined_channels = ["##learnpython"]
-            self.extra_notifications = set()
-            self.join_leave_hiding = {"show_by_default": True, "exception_nicks": []}
-            self.audio_notification = False
-        else:
-            self.host = dict_from_file["host"]
-            self.port = dict_from_file["port"]
-            self.ssl = dict_from_file["ssl"]
-            self.nick = dict_from_file["nick"]
-            self.username = dict_from_file["username"]
-            self.realname = dict_from_file["realname"]
-            self.password = dict_from_file["password"]
-            self.joined_channels = dict_from_file["joined_channels"]
-            self.extra_notifications = set(dict_from_file["extra_notifications"])
-            self.join_leave_hiding = dict_from_file["join_leave_hiding"]
-            self.audio_notification = dict_from_file["audio_notification"]
+        # The defaults passed to .get() are what the user sees when running Mantaray
+        # for the first time.
+        self.host: str = dict_from_file.get("host", "irc.libera.chat")
+        self.port: int = dict_from_file.get("port", 6697)
+        self.ssl: bool = dict_from_file.get("ssl", True)
+        self.nick: str = dict_from_file.get("nick", getuser())
+        self.username: str = dict_from_file.get("username", getuser())
+        self.realname: str = dict_from_file.get("realname", getuser())
+        self.password: str | None = dict_from_file.get("password", None)
+        self.joined_channels: list[str] = dict_from_file.get("joined_channels", ["##learnpython"])
+        self.extra_notifications: set[str] = set(dict_from_file.get("extra_notifications", []))
+        self.join_leave_hiding: JoinLeaveHidingSettings = dict_from_file.get("join_leave_hiding", {"show_by_default": True, "exception_nicks": []})
+        self.audio_notification: bool = dict_from_file.get("audio_notification", False)
+        self.last_away_status: str = dict_from_file.get("last_away_status", "Away")  # not empty
 
     def get_json(self) -> dict[str, Any]:
         return {
@@ -168,6 +146,7 @@ class ServerSettings:
             "extra_notifications": list(self.extra_notifications),
             "join_leave_hiding": self.join_leave_hiding,
             "audio_notification": self.audio_notification,
+            "last_away_status": self.last_away_status,
         }
 
     # Please save the settings after changing them.

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -129,9 +129,10 @@ class ServerSettings:
             "join_leave_hiding", {"show_by_default": True, "exception_nicks": []}
         )
         self.audio_notification: bool = dict_from_file.get("audio_notification", False)
+        # last_away_status is never empty
         self.last_away_status: str = dict_from_file.get(
             "last_away_status", "Away"
-        )  # not empty
+        )
 
     def get_json(self) -> dict[str, Any]:
         return {

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -127,11 +127,19 @@ class ServerSettings:
         self.username: str = dict_from_file.get("username", getuser())
         self.realname: str = dict_from_file.get("realname", getuser())
         self.password: str | None = dict_from_file.get("password", None)
-        self.joined_channels: list[str] = dict_from_file.get("joined_channels", ["##learnpython"])
-        self.extra_notifications: set[str] = set(dict_from_file.get("extra_notifications", []))
-        self.join_leave_hiding: JoinLeaveHidingSettings = dict_from_file.get("join_leave_hiding", {"show_by_default": True, "exception_nicks": []})
+        self.joined_channels: list[str] = dict_from_file.get(
+            "joined_channels", ["##learnpython"]
+        )
+        self.extra_notifications: set[str] = set(
+            dict_from_file.get("extra_notifications", [])
+        )
+        self.join_leave_hiding: JoinLeaveHidingSettings = dict_from_file.get(
+            "join_leave_hiding", {"show_by_default": True, "exception_nicks": []}
+        )
         self.audio_notification: bool = dict_from_file.get("audio_notification", False)
-        self.last_away_status: str = dict_from_file.get("last_away_status", "Away")  # not empty
+        self.last_away_status: str = dict_from_file.get(
+            "last_away_status", "Away"
+        )  # not empty
 
     def get_json(self) -> dict[str, Any]:
         return {

--- a/mantaray/config.py
+++ b/mantaray/config.py
@@ -130,9 +130,7 @@ class ServerSettings:
         )
         self.audio_notification: bool = dict_from_file.get("audio_notification", False)
         # last_away_status is never empty
-        self.last_away_status: str = dict_from_file.get(
-            "last_away_status", "Away"
-        )
+        self.last_away_status: str = dict_from_file.get("last_away_status", "Away")
 
     def get_json(self) -> dict[str, Any]:
         return {

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -46,7 +46,7 @@ def show_nick_and_away_dialog(
     content = ttk.Frame(dialog)
     content.pack(fill="both", expand=True)
     content.columnconfigure((0, 1), weight=1)  # type: ignore
-    content.rowconfigure((0, 1, 2, 3, 4, 5, 6, 7), pad=14)  # type: ignore
+    content.rowconfigure((0, 1, 2, 3, 4, 5), pad=14)  # type: ignore
 
     ttk.Label(content, text="Enter a new nickname here:").grid(columnspan=2)
 

--- a/mantaray/gui.py
+++ b/mantaray/gui.py
@@ -37,46 +37,74 @@ def _fix_tag_coloring_bug() -> None:
     )
 
 
-def ask_new_nick(parent: tkinter.Tk | tkinter.Toplevel, old_nick: str) -> str:
+def show_nick_and_away_dialog(
+    parent: tkinter.Tk | tkinter.Toplevel,
+    settings: config.ServerSettings,
+    was_away: bool,
+) -> tuple[str, bool]:
     dialog = tkinter.Toplevel()
     content = ttk.Frame(dialog)
     content.pack(fill="both", expand=True)
     content.columnconfigure((0, 1), weight=1)  # type: ignore
-    content.rowconfigure((0, 1, 2, 3), pad=14)  # type: ignore
+    content.rowconfigure((0, 1, 2, 3, 4, 5, 6, 7), pad=14)  # type: ignore
 
     ttk.Label(content, text="Enter a new nickname here:").grid(columnspan=2)
 
-    entry = ttk.Entry(content)
-    entry.grid(row=1, columnspan=2)
-    entry.insert(0, old_nick)
+    nick_entry = ttk.Entry(content)
+    nick_entry.grid(row=1, columnspan=2)
+    nick_entry.insert(0, settings.nick)
 
     ttk.Label(
-        content,
-        text="The same nick will be used on all channels.",
-        justify="center",
-        wraplength=160,
+        content, text="The same nick will be used on all channels.", justify="center"
     ).grid(row=2, columnspan=2)
 
-    result = old_nick
+    away_frame = ttk.Frame(content)
+    away_frame.grid(row=4, columnspan=2, sticky="we", padx=10, pady=30)
+    away_frame.columnconfigure(1, weight=1)
+
+    away_var = tkinter.BooleanVar()
+    ttk.Checkbutton(away_frame, text="Mark me as being away", variable=away_var).grid(
+        row=0, columnspan=2, sticky="w", pady=10
+    )
+
+    ttk.Label(away_frame, text="Reason: ").grid(row=1, column=0)
+    away_entry = ttk.Entry(away_frame)
+    away_entry.grid(row=1, column=1, sticky="we")
+    away_entry.insert(0, settings.last_away_status)
+
+    away_var.trace_add(
+        "write",
+        (
+            lambda *junk: away_entry.config(
+                state="normal" if away_var.get() else "disabled"
+            )
+        ),
+    )
+    away_var.set(was_away)
+
+    result = (settings.nick, was_away)
 
     def ok() -> None:
         nonlocal result
-        result = entry.get()
+        result = (nick_entry.get(), away_var.get())
+        settings.last_away_status = away_entry.get() or "Away"
+        settings.save()
         dialog.destroy()
 
-    ok_button = ttk.Button(
-        content, text="OK", command=ok, width=10, style="Accent.TButton"
-    ).grid(row=3, column=0, padx=(8, 5), sticky="ew")
-    cancel_button = ttk.Button(
-        content, text="Cancel", command=dialog.destroy, width=10
-    ).grid(row=3, column=1, padx=(5, 8), sticky="ew")
+    ttk.Button(content, text="OK", command=ok, width=15, style="Accent.TButton").grid(
+        row=5, column=0, padx=(8, 5), sticky="ew"
+    )
+    ttk.Button(content, text="Cancel", command=dialog.destroy, width=15).grid(
+        row=5, column=1, padx=(5, 8), sticky="ew"
+    )
 
-    entry.bind("<Return>", (lambda junk_event: ok()))
-    entry.bind("<Escape>", (lambda junk_event: dialog.destroy()))
+    dialog.bind("<Escape>", (lambda junk_event: dialog.destroy()))
+    for entry in [nick_entry, away_entry]:
+        entry.bind("<Return>", (lambda junk_event: ok()))
 
     dialog.resizable(False, False)
     dialog.transient(parent)
-    entry.focus()
+    nick_entry.focus()
     dialog.wait_window()
 
     return result
@@ -134,7 +162,7 @@ class IrcWidget(ttk.PanedWindow):
         entryframe.pack(side="bottom", fill="x")
 
         # TODO: add a tooltip to the button, it's not very obvious
-        self.nickbutton = ttk.Button(entryframe, command=self._show_change_nick_dialog)
+        self.nickbutton = ttk.Button(entryframe, command=self._on_nick_button_clicked)
         self.nickbutton.pack(side="left")
 
         # When the user is away, display the nick as gray in the button
@@ -171,11 +199,20 @@ class IrcWidget(ttk.PanedWindow):
         server_views.sort(key=(lambda v: self.view_selector.index(v.view_id)))
         return server_views
 
-    def _show_change_nick_dialog(self) -> None:
+    def _on_nick_button_clicked(self) -> None:
         server_view = self.get_current_view().server_view
-        new_nick = ask_new_nick(self.winfo_toplevel(), server_view.settings.nick)
+        new_nick, is_away = show_nick_and_away_dialog(
+            self.winfo_toplevel(), server_view.settings, server_view.core.is_away
+        )
+
         if new_nick != server_view.settings.nick:
             server_view.core.send(f"NICK {new_nick}")
+
+        if is_away != server_view.core.is_away:
+            if is_away:
+                server_view.core.send(f"AWAY :{server_view.settings.last_away_status}")
+            else:
+                server_view.core.send("AWAY")
 
     def on_enter_pressed(self, junk_event: object = None) -> None:
         view = self.get_current_view()

--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -719,7 +719,7 @@ def _handle_received_message(
                 user_view.userlist.set_away(
                     server_view.settings.nick,
                     is_away=True,
-                    reason=server_view.last_away_status,
+                    reason=server_view.settings.last_away_status,
                 )
 
         server_view.core.is_away = True

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -402,10 +402,6 @@ class ServerView(View):
         # you likely want to also use the GUI to configure automatic joining.
         self.last_slash_join_channel: str | None = None
 
-        # Similarly, we display the resulting status of "/away <status>" when the
-        # server tells us that it successfully marked the user as away.
-        self.last_away_status: str | None = None
-
     def _run_core(self) -> None:
         self.core.run_one_step()
 


### PR DESCRIPTION
Mantaray already has `/away` and `/back`, but they aren't very intuitive to users who don't know about IRC commands. Since #331 the nick button shows whether you are away, so I think it makes sense to let you also change your away status based on that.

Because the away status is now set with an entry widget, I also saved the most recently used away status in the settings, so that the entry will show it by default when you make yourself away next time.