### PR TITLE
Add biberao mode

### DIFF
--- a/mantaray/received.py
+++ b/mantaray/received.py
@@ -131,7 +131,9 @@ def _add_privmsg_to_view(
             view.add_notification(f"{sender} {text}")
         else:
             if isinstance(view, views.ChannelView):
-                view.add_notification(f"<{sender}> {text}")
+                view.add_notification(
+                    f"<{sender}> {text}", biberao_mode=(sender == "biberao")
+                )
             else:
                 view.add_notification(text)
 

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -202,6 +202,7 @@ class View:
         self.view_id = irc_widget.view_selector.insert(parent_view_id, "end", text=name)
         self._name = name
         self.notification_count = 0
+        self._biberao_notification_timers: list[str] = []
 
         self.textwidget = tkinter.Text(
             irc_widget.textwidget_container,
@@ -272,8 +273,18 @@ class View:
     def _window_has_focus(self) -> bool:
         return bool(self.irc_widget.tk.eval("focus"))
 
-    def add_notification(self, popup_text: str) -> None:
+    def add_notification(self, popup_text: str, *, biberao_mode: bool = False) -> None:
         if self.irc_widget.get_current_view() == self and self._window_has_focus():
+            return
+
+        if biberao_mode:
+            # Show the notification later. This way, if biberao sends me
+            # many messages with a few seconds between them, I see them all
+            # at once when I look at mantaray after the first notification.
+            timeout_id = self.textwidget.after(
+                60000, (lambda: self.add_notification(popup_text))
+            )
+            self._biberao_notification_timers.append(timeout_id)
             return
 
         self.notification_count += 1
@@ -288,6 +299,9 @@ class View:
         _show_popup(self.view_name, popup_text)
 
     def mark_seen(self) -> None:
+        for timeout_id in self._biberao_notification_timers:
+            self.textwidget.after_cancel(timeout_id)
+
         self.notification_count = 0
         self._update_view_selector()
         self.irc_widget.event_generate("<<NotificationCountChanged>>")

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -196,6 +196,9 @@ class MessagePart:
         self.tags = tags.copy()
 
 
+BIBERAO_MODE_DELAY = 60  # seconds
+
+
 class View:
     def __init__(self, irc_widget: IrcWidget, name: str, *, parent_view_id: str = ""):
         self.irc_widget = irc_widget
@@ -282,7 +285,7 @@ class View:
             # many messages with a few seconds between them, I see them all
             # at once when I look at mantaray after the first notification.
             timeout_id = self.textwidget.after(
-                60000, (lambda: self.add_notification(popup_text))
+                BIBERAO_MODE_DELAY * 1000, (lambda: self.add_notification(popup_text))
             )
             self._biberao_notification_timers.append(timeout_id)
             return

--- a/mantaray/views.py
+++ b/mantaray/views.py
@@ -304,6 +304,7 @@ class View:
     def mark_seen(self) -> None:
         for timeout_id in self._biberao_notification_timers:
             self.textwidget.after_cancel(timeout_id)
+        self._biberao_notification_timers.clear()
 
         self.notification_count = 0
         self._update_view_selector()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -118,13 +118,13 @@ def test_biberao_mode(alice, bob, wait_until, mocker, monkeypatch):
     start = time.time()
     wait_until(lambda: "blah blah" in alice.text())
     end = time.time()
-    assert end - start < 0.1
+    assert end - start < 0.5
 
     # But because the biberao mode delay was set to 3 seconds, that's how
     # long it takes for the notification to arrive
     start = time.time()
     wait_until(lambda: views._show_popup.call_count != 0)
     end = time.time()
-    assert 2.9 < end - start < 3.1
+    assert 2.5 < end - start < 3.5
 
     views._show_popup.assert_called_once_with("#autojoin", "<biberao> Alice: blah blah")


### PR DESCRIPTION
Talking with biberao usually looks like this:

![screenshot-1709323043](https://github.com/Akuli/mantaray/assets/18505570/bcd66bd2-82e4-4dfa-bfee-d79fa2cd84cc)

Basically, I either get pinged for new messages continuously, or I don't notice biberao's messages at all, depending on whether the "Show notifications for all messages" checkbox is checked (when right-clicking the channel).

This PR delays notifications of biberao's messages by 1 minute, so that I cannot get multiple notifications per minute, but I notice the messages eventually.